### PR TITLE
allow toolbar button states to change when selection is collapsed

### DIFF
--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -23,10 +23,17 @@ function fireEvent (element, event, keyCode, ctrlKey, target, relatedTarget) {
    }
 }
 
-function selectElementContents(el) {
+function selectElementContents(el, options) {
+    options = options || {};
+
     var range = document.createRange(),
         sel = window.getSelection();
     range.selectNodeContents(el);
+
+    if (options.collapse) {
+      range.collapse(options.collapse === true);
+    }
+
     sel.removeAllRanges();
     sel.addRange(range);
 }

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -81,6 +81,19 @@ describe('Selection TestCase', function () {
                 expect(editor.setToolbarButtonStates).toHaveBeenCalled();
                 expect(editor.showToolbarActions).toHaveBeenCalled();
             });
+
+            it('should update button states when updateOnEmptySelection is true and the selection is empty', function () {
+              spyOn(MediumEditor.prototype, 'setToolbarButtonStates').and.callThrough();
+
+              var editor = new MediumEditor('.editor', {
+                  updateOnEmptySelection: true
+              });
+
+              selectElementContents(this.el, { collapse: 'toStart' });
+              editor.checkSelection();
+
+              expect(editor.setToolbarButtonStates.calls.count()).toEqual(1);
+            });
         });
     });
 

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -767,7 +767,7 @@ else if (typeof define === 'function' && define.amd) {
             if (this.keepToolbarAlive !== true && !this.options.disableToolbar) {
 
                 newSelection = this.options.contentWindow.getSelection();
-                if (newSelection.toString().trim() === '' ||
+                if ((!this.options.updateOnEmptySelection && newSelection.toString().trim() === '') ||
                     (this.options.allowMultiParagraphSelection === false && this.hasMultiParagraphs()) ||
                     this.selectionInContentEditableFalse()) {
 
@@ -912,7 +912,7 @@ else if (typeof define === 'function' && define.amd) {
 
                 this.toolbar.style.left = containerRect.left + "px";
 
-            } else {
+            } else if (!selection.isCollapsed) {
                 range = selection.getRangeAt(0);
                 boundary = range.getBoundingClientRect();
                 middleBoundary = (boundary.left + boundary.right) / 2;


### PR DESCRIPTION
This pull request allows for a config option that will make button states update even when the selection is collapsed.

Use case: imagine that you want to know what toolbar should be active in the range that the cursor is in, even when the cursor has no selection.