### PR TITLE
Add optional 'onhidetoolbar' method

### DIFF
--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -105,6 +105,7 @@ describe('Toolbar TestCase', function () {
 
         it('should call onHideToolbar when toolbar is hidden', function () {
             var editor = new MediumEditor('.editor');
+            editor.toolbar.classList.add('medium-editor-toolbar-active');
             editor.onHideToolbar = function() {};
 
             spyOn(editor, 'onHideToolbar').and.callThrough();

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -1,6 +1,6 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, selectElementContents, runs,
-         waitsFor, tearDown, xit */
+         fireEvent, waitsFor, tearDown, xit */
 
 describe('Toolbar TestCase', function () {
     'use strict';
@@ -101,6 +101,18 @@ describe('Toolbar TestCase', function () {
             }, 500);
 
 
+        });
+
+        it('should call onHideToolbar when toolbar is hidden', function () {
+            var editor = new MediumEditor('.editor');
+            editor.onHideToolbar = function() {};
+
+            spyOn(editor, 'onHideToolbar').and.callThrough();
+
+            fireEvent(editor.elements[0], 'focus');
+            fireEvent(editor.elements[0], 'blur');
+
+            expect(editor.onHideToolbar).toHaveBeenCalled();
         });
 
         // jasmine 2.0 changed async tests, runs no longer exists

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -269,6 +269,7 @@ else if (typeof define === 'function' && define.amd) {
 
         bindBlur: function(i) {
             var self = this,
+                timeout,
                 blurFunction = function(e){
                     // If it's not part of the editor, or the toolbar
                     if ( e.target !== self.toolbar
@@ -280,8 +281,9 @@ else if (typeof define === 'function' && define.amd) {
                         // Activate the placeholder
                         self.placeholderWrapper(self.elements[0], e);
 
+                        clearTimeout(timeout);
                         // Hide the toolbar after a small delay so we can prevent this on toolbar click
-                        setTimeout(function(){
+                        timeout = setTimeout(function(){
                             if ( !self.keepToolbarAlive ) {
                                 self.hideToolbarActions();
                             }

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1114,7 +1114,7 @@ else if (typeof define === 'function' && define.amd) {
 
         hideToolbarActions: function () {
             this.keepToolbarAlive = false;
-            if (this.toolbar !== undefined) {
+            if (this.toolbar !== undefined && this.toolbar.classList.contains('medium-editor-toolbar-active')) {
                 this.toolbar.classList.remove('medium-editor-toolbar-active');
                 if (this.onHideToolbar) {
                     this.onHideToolbar();

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1116,6 +1116,9 @@ else if (typeof define === 'function' && define.amd) {
             this.keepToolbarAlive = false;
             if (this.toolbar !== undefined) {
                 this.toolbar.classList.remove('medium-editor-toolbar-active');
+                if (this.onHideToolbar) {
+                    this.onHideToolbar();
+                }
             }
         },
 


### PR DESCRIPTION
Use case: as a developer, I want to add some custom behavior that will fire on my MediumEditor instance when the toolbar is hidden.

This changeset also adds a little bit of code that will clear any existing `setTimeout` function that exists when `blurFunction` is re-called.