### PR TITLE
support Japanese Kanji conversion

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -426,7 +426,8 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         bindParagraphCreation: function (index) {
-            var self = this;
+            var self = this,
+                keyDownCode = 0;
             this.on(this.elements[index], 'keypress', function (e) {
                 var node = getSelectionStart.call(self),
                     tagName;
@@ -438,6 +439,10 @@ else if (typeof define === 'function' && define.amd) {
                 }
             });
 
+            this.on(this.elements[index], 'keydown', function (e) {
+                keyDownCode = e.which;
+            });
+
             this.on(this.elements[index], 'keyup', function (e) {
                 var node = getSelectionStart.call(self),
                     tagName,
@@ -446,7 +451,7 @@ else if (typeof define === 'function' && define.amd) {
                 if (node && node.getAttribute('data-medium-element') && node.children.length === 0 && !(self.options.disableReturn || node.getAttribute('data-disable-return'))) {
                     document.execCommand('formatBlock', false, 'p');
                 }
-                if (e.which === 13) {
+                if (e.which === 13 && e.which === keyDownCode ) {
                     node = getSelectionStart.call(self);
                     tagName = node.tagName.toLowerCase();
                     editorElement = self.getSelectionElement();
@@ -483,9 +488,15 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         bindReturn: function (index) {
-            var self = this;
+            var self = this,
+                keyDownCode = 0;
+
+            this.on(this.elements[index], 'keydown', function (e) {
+                keyDownCode = e.which;
+            });
+
             this.on(this.elements[index], 'keypress', function (e) {
-                if (e.which === 13) {
+                if (e.which === 13 && e.which === keyDownCode ) {
                     if (self.options.disableReturn || this.getAttribute('data-disable-return')) {
                         e.preventDefault();
                     } else if (self.options.disableDoubleReturn || this.getAttribute('data-disable-double-return')) {
@@ -1152,18 +1163,23 @@ else if (typeof define === 'function' && define.amd) {
         bindAnchorForm: function () {
             var linkCancel = this.anchorForm.querySelector('a.medium-editor-toobar-anchor-close'),
                 linkSave = this.anchorForm.querySelector('a.medium-editor-toobar-anchor-save'),
-                self = this;
+                self = this,
+                keyDownCode = 0;
 
             this.on(this.anchorForm, 'click', function (e) {
                 e.stopPropagation();
                 self.keepToolbarAlive = true;
             });
 
+            this.on(this.anchorInput, 'keydown', function (e) {
+                keyDownCode = e.which;
+            });
+
             this.on(this.anchorInput, 'keyup', function (e) {
                 var button = null,
                     target;
 
-                if (e.keyCode === 13) {
+                if (e.keyCode === 13 && e.keyCode === keyDownCode) {
                     e.preventDefault();
                     if (self.options.anchorTarget && self.anchorTarget.checked) {
                         target = "_blank";


### PR DESCRIPTION
when press enter key to confirm Kanji conversion. it was created the unwanted paragraph.
so check the keyup and keydown keycode and if both are equarl then trigger the event.

this is because when press enter key for Kanji conversion. it's returns different keycodes both up(229) and down(13)

http://en.wikipedia.org/wiki/Japanese_input_methods#Kana_to_kanji_conversion