### PR TITLE
Ensure medium ID's uniqueness

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -71,7 +71,7 @@ describe('Anchor Preview TestCase', function () {
 
             // blur the editable area and focus onto the input for the anchor form
             spyOn(MediumEditor.prototype, 'hideToolbarActions').and.callThrough();
-            fireEvent(editor.elements[0], 'blur', undefined, undefined, editor.elements[0], document.querySelector('#medium-editor-toolbar-form-anchor input'));
+            fireEvent(editor.elements[0], 'blur', undefined, undefined, editor.elements[0], document.querySelector('#medium-editor-toolbar-form-anchor-' + editor.id + ' input'));
             jasmine.clock().tick(1);
             expect(editor.hideToolbarActions).not.toHaveBeenCalled();
 

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -144,6 +144,21 @@ describe('Initialization TestCase', function () {
             expect(editor3.id).toBe(3);
         });
 
+        it('should not reset ID when deactivated and then re-initialized', function () {
+            var secondEditor = document.createElement('div'),
+                editor1 = new MediumEditor('.editor'),
+                editor2;
+
+            secondEditor.className = 'editor-two';
+            document.body.appendChild(secondEditor);
+
+            editor2 = new MediumEditor('.editor-two');
+            editor1.deactivate();
+            editor1.init('.editor');
+
+            expect(editor1.id).not.toEqual(editor2.id);
+        });
+
         it('should use document.body as element container when no container element is specified', function () {
             spyOn(document.body, 'appendChild').and.callThrough();
             (function () {

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -663,7 +663,7 @@ else if (typeof define === 'function' && define.amd) {
                 btn,
                 ext;
 
-            ul.id = 'medium-editor-toolbar-actions';
+            ul.id = 'medium-editor-toolbar-actions' + this.id;
             ul.className = 'medium-editor-toolbar-actions clearfix';
 
             for (i = 0; i < btns.length; i += 1) {
@@ -723,7 +723,7 @@ else if (typeof define === 'function' && define.amd) {
 
 
             anchor.className = 'medium-editor-toolbar-form-anchor';
-            anchor.id = 'medium-editor-toolbar-form-anchor';
+            anchor.id = 'medium-editor-toolbar-form-anchor-' + this.id;
             anchor.appendChild(input);
 
             anchor.appendChild(save);

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -181,6 +181,8 @@ else if (typeof define === 'function' && define.amd) {
         isIE: ((navigator.appName === 'Microsoft Internet Explorer') || ((navigator.appName === 'Netscape') && (new RegExp('Trident/.*rv:([0-9]{1,}[.0-9]{0,})').exec(navigator.userAgent) !== null))),
 
         init: function (elements, options) {
+            var uniqueId = 1;
+
             this.options = extend(options, this.defaults);
             this.setElementSelection(elements);
             if (this.elements.length === 0) {
@@ -190,7 +192,13 @@ else if (typeof define === 'function' && define.amd) {
             if (!this.options.elementsContainer) {
                 this.options.elementsContainer = document.body;
             }
-            this.id = this.options.elementsContainer.querySelectorAll('.medium-editor-toolbar').length + 1;
+
+            while (this.options.elementsContainer.querySelector('#medium-editor-toolbar-' + uniqueId)) {
+                uniqueId = uniqueId + 1;
+            }
+
+            this.id = uniqueId;
+
             return this.setup();
         },
 


### PR DESCRIPTION
found a case where different medium-editor instances could be assigned the same ID if the first instance was deactivated, then activated (it would get re-assigned to an already-assigned ID).

this changeset also fixes a few cases where an ID was being assigned to a smaller piece of medium-editor (e.g. `#medium-editor-toolbar-actions` without a unique identifier being appended to the end of that smaller piece)