### PR TITLE
Avoid grabbing selection on keypress when it's not being used

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -428,9 +428,10 @@ else if (typeof define === 'function' && define.amd) {
         bindParagraphCreation: function (index) {
             var self = this;
             this.on(this.elements[index], 'keypress', function (e) {
-                var node = getSelectionStart.call(self),
+                var node,
                     tagName;
                 if (e.which === 32) {
+                    node = getSelectionStart.call(self);
                     tagName = node.tagName.toLowerCase();
                     if (tagName === 'a') {
                         document.execCommand('unlink', false, null);


### PR DESCRIPTION
This will be a performance improvement.  It will avoid calling into `getSelectionStart` until we know we actually need the selection (if the user hits spacebar, we need to know if their in an anchor or not)