### PR TITLE
Support disabling anchorForm

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -80,6 +80,7 @@ describe('Initialization TestCase', function () {
                 disableDoubleReturn: false,
                 disableEditing: false,
                 disableToolbar: false,
+                disableAnchorForm: false,
                 elementsContainer: document.body,
                 contentWindow: window,
                 ownerDocument: document,

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -33,6 +33,22 @@ describe('Toolbar TestCase', function () {
             expect(editor.toolbar.className).toMatch(/medium-editor-toolbar/);
             expect(document.querySelectorAll('.medium-editor-toolbar').length).toBe(1);
         });
+
+        it('should not create an anchor form element if disableAnchorForm is set to true', function() {
+            expect(document.querySelectorAll('.medium-editor-toolbar-form-anchor').length).toBe(0);
+            var editor = new MediumEditor('.editor', {
+                disableAnchorForm: true
+            });
+            expect(editor.toolbar.querySelectorAll('.medium-editor-toolbar-form-anchor').length).toBe(0);
+        });
+
+        it('should not call MediumEditor\'s toolbarFormAnchor method if disableAnchorForm is set to true', function() {
+            spyOn(MediumEditor.prototype, 'toolbarFormAnchor').and.callThrough();
+            var editor = new MediumEditor('.editor', {
+                disableAnchorForm: true
+            });
+            expect(editor.toolbarFormAnchor).not.toHaveBeenCalled();
+        });
     });
 
     describe('Deactive', function () {

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -159,6 +159,7 @@ else if (typeof define === 'function' && define.amd) {
             disableDoubleReturn: false,
             disableToolbar: false,
             disableEditing: false,
+            disableAnchorForm: false,
             elementsContainer: false,
             contentWindow: window,
             ownerDocument: document,
@@ -619,13 +620,15 @@ else if (typeof define === 'function' && define.amd) {
             }
             this.toolbar = this.createToolbar();
             this.keepToolbarAlive = false;
-            this.anchorForm = this.toolbar.querySelector('.medium-editor-toolbar-form-anchor');
-            this.anchorInput = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-input');
-            this.anchorTarget = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-target');
-            this.anchorButton = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-button');
             this.toolbarActions = this.toolbar.querySelector('.medium-editor-toolbar-actions');
             this.anchorPreview = this.createAnchorPreview();
 
+            if (!this.options.disableAnchorForm) {
+                this.anchorForm = this.toolbar.querySelector('.medium-editor-toolbar-form-anchor');
+                this.anchorInput = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-input');
+                this.anchorTarget = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-target');
+                this.anchorButton = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-button');   
+            }
             return this;
         },
 
@@ -641,7 +644,9 @@ else if (typeof define === 'function' && define.amd) {
             }
 
             toolbar.appendChild(this.toolbarButtons());
-            toolbar.appendChild(this.toolbarFormAnchor());
+            if (!this.options.disableAnchorForm) {
+                toolbar.appendChild(this.toolbarFormAnchor());
+            }
             this.options.elementsContainer.appendChild(toolbar);
             return toolbar;
         },
@@ -740,7 +745,7 @@ else if (typeof define === 'function' && define.amd) {
             this.checkSelectionWrapper = function (e) {
 
                 // Do not close the toolbar when bluring the editable area and clicking into the anchor form
-                if (e && self.clickingIntoArchorForm(e)) {
+                if (!self.options.disableAnchorForm && e && self.clickingIntoArchorForm(e)) {
                     return false;
                 }
 
@@ -773,7 +778,7 @@ else if (typeof define === 'function' && define.amd) {
 
                     if ( !this.options.staticToolbar ) {
                         this.hideToolbarActions();
-                    } else if (this.anchorForm.style.display === 'block') {
+                    } else if (this.anchorForm && this.anchorForm.style.display === 'block') {
                         this.setToolbarButtonStates();
                         this.showToolbarActions();
                     }
@@ -1012,7 +1017,9 @@ else if (typeof define === 'function' && define.amd) {
                 this.setToolbarPosition();
                 this.setToolbarButtonStates();
             } else if (action === 'anchor') {
-                this.triggerAnchorAction(e);
+                if (!this.options.disableAnchorForm) {
+                    this.triggerAnchorAction(e);
+                }
             } else if (action === 'image') {
                 this.options.ownerDocument.execCommand('insertImage', false, this.options.contentWindow.getSelection());
             } else {
@@ -1047,7 +1054,7 @@ else if (typeof define === 'function' && define.amd) {
             if (selectedParentElement.tagName &&
                     selectedParentElement.tagName.toLowerCase() === 'a') {
                 this.options.ownerDocument.execCommand('unlink', false, null);
-            } else {
+            } else if (this.anchorForm) {
                 if (this.anchorForm.style.display === 'block') {
                     this.showToolbarActions();
                 } else {
@@ -1120,7 +1127,9 @@ else if (typeof define === 'function' && define.amd) {
         showToolbarActions: function () {
             var self = this,
                 timer;
-            this.anchorForm.style.display = 'none';
+            if (this.anchorForm) {
+                this.anchorForm.style.display = 'none';
+            }
             this.toolbarActions.style.display = 'block';
             this.keepToolbarAlive = false;
             clearTimeout(timer);
@@ -1140,6 +1149,10 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         showAnchorForm: function (link_value) {
+            if (!this.anchorForm) {
+                return;
+            }
+
             this.toolbarActions.style.display = 'none';
             this.saveSelection();
             this.anchorForm.style.display = 'block';
@@ -1150,6 +1163,10 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         bindAnchorForm: function () {
+            if (!this.anchorForm) {
+                return this;
+            }
+
             var linkCancel = this.anchorForm.querySelector('a.medium-editor-toobar-anchor-close'),
                 linkSave = this.anchorForm.querySelector('a.medium-editor-toobar-anchor-save'),
                 self = this;
@@ -1335,7 +1352,7 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         anchorPreviewClickHandler: function (e) {
-            if (this.activeAnchor) {
+            if (!this.options.disableAnchorForm && this.activeAnchor) {
 
                 var self = this,
                     range = this.options.ownerDocument.createRange(),


### PR DESCRIPTION
When 'disableAnchorForm' is passed as an option:
- Don't create the anchor form element
- Don't attach event handlers to the document, window, and/or anchor form which are used soley for handling user interaction with the anchorForm