### PR TITLE
Support disabling placeholders

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -80,6 +80,7 @@ describe('Initialization TestCase', function () {
                 disableDoubleReturn: false,
                 disableEditing: false,
                 disableToolbar: false,
+                disablePlaceholders: false,
                 elementsContainer: document.body,
                 contentWindow: window,
                 ownerDocument: document,

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -76,4 +76,21 @@ describe('Placeholder TestCase', function () {
         expect(placeholder).toEqual("'Custom placeholder'");
     });
 
+    it('should not set placeholder for empty elements when disablePlaceholders is set to true', function () {
+        var editor = new MediumEditor('.editor', {
+            disablePlaceholders: true
+        });
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+    });
+
+    it('should not add a placeholder to empty elements on blur when disablePlaceholders is set to true', function () {
+        this.el.innerHTML = 'some text';
+        var editor = new MediumEditor('.editor', {
+            disablePlaceholders: true
+        });
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+        editor.elements[0].innerHTML = '';
+        fireEvent(document.querySelector('div'), 'click');
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+    });
 });

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -159,6 +159,7 @@ else if (typeof define === 'function' && define.amd) {
             disableDoubleReturn: false,
             disableToolbar: false,
             disableEditing: false,
+            disablePlaceholders: false,
             elementsContainer: false,
             contentWindow: window,
             ownerDocument: document,
@@ -278,7 +279,9 @@ else if (typeof define === 'function' && define.amd) {
                         && !isDescendant(self.anchorPreview, e.target)) {
 
                         // Activate the placeholder
-                        self.placeholderWrapper(self.elements[0], e);
+                        if (!self.options.disablePlaceholders) {
+                            self.placeholderWrapper(self.elements[0], e);
+                        }
 
                         // Hide the toolbar after a small delay so we can prevent this on toolbar click
                         setTimeout(function(){
@@ -297,6 +300,10 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         bindKeypress: function(i) {
+            if (this.options.disablePlaceholders) {
+                return this;
+            }
+
             var self = this;
 
             // Set up the keypress events
@@ -311,8 +318,10 @@ else if (typeof define === 'function' && define.amd) {
             var self = this;
 
             this.elements[i].addEventListener('click', function(){
-                // Remove placeholder
-                this.classList.remove('medium-editor-placeholder');
+                if (!self.options.disablePlaceholders) {
+                    // Remove placeholder
+                    this.classList.remove('medium-editor-placeholder');
+                }
 
                 if ( self.options.staticToolbar ) {
                     self.setToolbarPosition();
@@ -331,8 +340,10 @@ else if (typeof define === 'function' && define.amd) {
 
             for (i = 0; i < this.elements.length; i += 1) {
 
-                // Active all of the placeholders
-                this.activatePlaceholder(this.elements[i]);
+                if (!this.options.disablePlaceholders) {
+                    // Active all of the placeholders
+                    this.activatePlaceholder(this.elements[i]);
+                }
 
                 // Bind the return and tab keypress events
                 this.bindReturn(i)
@@ -1598,6 +1609,10 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         setPlaceholders: function () {
+            if (this.options.disablePlaceholders) {
+                return this;
+            }
+
             var i,
                 activatePlaceholder = function (el) {
                     if (!(el.querySelector('img')) &&


### PR DESCRIPTION
When `disablePlaceholders` is passed as an option to medium-editor:
- Do not add/remove the 'medium-editor-placeholder' class on the contenteditable element
- Don't attach event handlers which had the sole purpose of handling when a placeholder should be shown/hidden