### PR TITLE
Handle ESC key in link editor

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1220,6 +1220,11 @@ else if (typeof define === 'function' && define.amd) {
 
                     self.createLink(this, target, button);
                 }
+                else if (e.keyCode === 27) {
+                    e.preventDefault();
+                    self.showToolbarActions();
+                    restoreSelection.call(self, self.savedSelection);
+                }
             });
 
             this.on(linkSave, 'click', function(e) {


### PR DESCRIPTION
When the link editor is open, let the user hit ESC to close it and return to the main toolbar (just like the X button)