### PR TITLE
Standardize usage of setTimeout for UX delays vs debouncing vs deferring

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1,6 +1,4 @@
 /*global module, console, define*/
-var DEBOUNCE_INTERVAL = 50;
-
 function MediumEditor(elements, options) {
     'use strict';
     return this.init(elements, options);
@@ -40,7 +38,8 @@ else if (typeof define === 'function' && define.amd) {
 
     // https://github.com/jashkenas/underscore
     function debounce(func, wait) {
-        var timeout, 
+        var DEBOUNCE_INTERVAL = 50,
+            timeout, 
             args, 
             context, 
             timestamp, 

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -320,6 +320,10 @@ else if (typeof define === 'function' && define.amd) {
             }
         },
 
+        // handleBlur is debounced because:
+        // - This method could be called many times due to the type of event handlers that are calling it
+        // - We want a slight delay so that other events in the stack can run, some of which may
+        //   prevent the toolbar from being hidden (via this.keepToolbarAlive).
         handleBlur: debounce(function() {
             if ( !this.keepToolbarAlive ) {
                 this.hideToolbarActions();
@@ -1208,6 +1212,8 @@ else if (typeof define === 'function' && define.amd) {
             }
             this.toolbarActions.style.display = 'block';
             this.keepToolbarAlive = false;
+            // Using setTimeout + options.delay because:
+            // We will actually be displaying the toolbar, which should be controlled by options.delay
             setTimeout(function () {
                 self.showToolbar();
             }, this.options.delay);
@@ -1430,6 +1436,8 @@ else if (typeof define === 'function' && define.amd) {
                 range.selectNodeContents(self.activeAnchor);
                 sel.removeAllRanges();
                 sel.addRange(range);
+                // Using setTimeout + options.delay because:
+                // We may actually be displaying the anchor preview, which should be controlled by options.delay
                 setTimeout(function () {
                     if (self.activeAnchor) {
                         self.showAnchorForm(self.activeAnchor.href);
@@ -1467,8 +1475,9 @@ else if (typeof define === 'function' && define.amd) {
                 }
                 this.activeAnchor = e.target;
                 this.on(this.activeAnchor, 'mouseout', leaveAnchor);
-                // show the anchor preview according to the configured delay
-                // if the mouse has not left the anchor tag in that time
+                // Using setTimeout + options.delay because:
+                // - We're going to show the anchor preview according to the configured delay
+                //   if the mouse has not left the anchor tag in that time
                 setTimeout(function () {
                     if (overAnchor) {
                         self.showAnchorPreview(e.target);
@@ -1568,6 +1577,9 @@ else if (typeof define === 'function' && define.amd) {
             }
         },
 
+        // handleResize is debounced because:
+        // - It will be called when the browser is resizing, which can fire many times very quickly
+        // - For some event (like resize) a slight lag in UI responsiveness is OK and provides performance benefits
         handleResize: debounce(function() {
             this.positionToolbarIfShown();
         }),


### PR DESCRIPTION
There is a delay when hiding the toolbar, so that if you have multiple instances of medium-editor on the page, you can cause multiple toolbars to appear at the same time.  This delay is NOT controlled by the `delay` option, it is hard coded and doesn't appear to be necessary, at least as far as I can tell.

The goal of these changes is to make sure we're using the `delay` option properly, and try to remove places where a hard-coded delay is actually creating a UI lag. 

+ The 'delay' option indicates that it should be used for the amount of time to delay the toolbar or anchorPreview from being displayed.  So, ensure this value is only being used in places where we would show the toolbar or anchor preview
+ For places in the code where we just want to debounce (prevent a method from being called too many times too rapidly) use a standard time interval and a `debounce` helper method
+ For places in the code where we just want to delay a method from being called immediately, again use the debounce time interval via the `debounce` helper
+ Create standard helper methods for hiding/showing toolbar as well as checking if toolbar is visible.  Use these everywhere to help control flows which manipulate the toolbar.
