### PR TITLE
Pass medium instance to calls to extension.getButton()

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -734,7 +734,7 @@ else if (typeof define === 'function' && define.amd) {
             for (i = 0; i < btns.length; i += 1) {
                 if (this.options.extensions.hasOwnProperty(btns[i])) {
                     ext = this.options.extensions[btns[i]];
-                    btn = ext.getButton !== undefined ? ext.getButton() : null;
+                    btn = ext.getButton !== undefined ? ext.getButton(this) : null;
                 } else {
                     btn = this.buttonTemplate(btns[i]);
                 }


### PR DESCRIPTION
This allows us to use some parts of medium-editor when we create custom buttons for the toolbar