### PR TITLE
Support enabling/disabling checkSelection updates externally

### DIFF
--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -144,6 +144,41 @@ describe('Toolbar TestCase', function () {
             expect(editor.toolbar.classList.contains('medium-editor-toolbar-active')).toBe(false);
         });
 
+        it('should enable bold button in toolbar when bold text is selected', function() {
+            var editor = null;
+
+            this.el.innerHTML = 'lorem ipsum <b><div id="cef_el">dolor</div></b>';
+
+            editor = new MediumEditor(document.querySelectorAll('.editor'), { delay: 0 });
+
+            selectElementContents(document.getElementById('cef_el'));
+            editor.checkSelection();
+
+            jasmine.clock().tick(51);
+            expect(editor.toolbar.querySelector('button[data-action="bold"]').classList.contains('medium-editor-button-active')).toBe(true);
+        });
+
+        it('should not activate buttons in toolbar when stopSelectionUpdates has been called, but should activate buttons after startSelectionUpdates is called', function() {
+            var editor = null;
+
+            this.el.innerHTML = 'lorem ipsum <b><div id="cef_el">dolor</div></b>';
+
+            editor = new MediumEditor(document.querySelectorAll('.editor'), { delay: 0 });
+
+            selectElementContents(document.getElementById('cef_el'));
+            editor.stopSelectionUpdates();
+            editor.checkSelection();
+
+            jasmine.clock().tick(51);
+            expect(editor.toolbar.querySelector('button[data-action="bold"]').classList.contains('medium-editor-button-active')).toBe(false);
+
+            editor.startSelectionUpdates();
+            editor.checkSelection();
+
+            jasmine.clock().tick(51);
+            expect(editor.toolbar.querySelector('button[data-action="bold"]').classList.contains('medium-editor-button-active')).toBe(true);
+        });
+
         it('should call onHideToolbar when toolbar is hidden', function () {
             var editor = new MediumEditor('.editor');
             editor.toolbar.classList.add('medium-editor-toolbar-active');

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -847,11 +847,21 @@ else if (typeof define === 'function' && define.amd) {
             return this;
         },
 
+        stopSelectionUpdates: function() {
+            this.preventSelectionUpdates = true;
+        },
+
+        startSelectionUpdates: function() {
+            this.preventSelectionUpdates = false;
+        },
+
         checkSelection: function () {
             var newSelection,
                 selectionElement;
 
-            if (this.keepToolbarAlive !== true && !this.options.disableToolbar) {
+            if (!this.preventSelectionUpdates &&
+                this.keepToolbarAlive !== true &&
+                !this.options.disableToolbar) {
 
                 newSelection = this.options.contentWindow.getSelection();
                 if ((!this.options.updateOnEmptySelection && newSelection.toString().trim() === '') ||


### PR DESCRIPTION
+ Calling `MediumEditor.stopSelectionUpdates()` will prevent the logic in `checkSelection()` from running
+ Calling `MediumEditor.startSelectionUpdates()` will undo the action done by `stopSelectionUpdates()` and allow the logic in `checkSelection()` to behave normally.