### PR TITLE
Standardize where in the DOM a range begins

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you want to support IE9, you will need to use a classList pollyfill, like Eli
 * __forcePlainText__: Forces pasting as plain text. Default: true
 * __placeholder__: Defines the default placeholder for empty contenteditables when __disablePlaceholders__ is not set to true. You can overwrite it by setting a data-placeholder attribute on your elements. Default: 'Type your text'
 * __secondHeader__: HTML tag to be used as second header. Default: h4
+* __standardizeSelectionStart__: Standardizes how the beginning of a range is decided between browsers whenever the selected text is analyzed for updating toolbar buttons status
 
 ### Toolbar options
 * __activeButtonClass__: CSS class added to active buttons in the toolbar. Default: 'medium-editor-button-active'

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -83,6 +83,7 @@ describe('Initialization TestCase', function () {
                 disableAnchorForm: false,
                 disablePlaceholders: false,
                 elementsContainer: document.body,
+                standardizeSelectionStart: false,
                 contentWindow: window,
                 ownerDocument: document,
                 firstHeader: 'h3',


### PR DESCRIPTION
This is a proposed fix for Issue #371 

In firefox, there are cases (ie doubleclick of a word) where the selectionRange start will be at the very end of an element.  In other browsers, the selectionRange start would instead be at the very beginning of an element that actually has content.

example:
```
<div contenteditable="true">
    <span>foo</span><span>bar</span>
</div>
````
If the text `bar` is selected, most browsers will have the selectionRange start at the beginning of the `bar` span.  However, there are cases where firefox will have the selectionRange start at the end of the `foo` span.  The contenteditable behavior will be ok, but if there are any properties on the `bar` span, they won't be reflected accurately in the toolbar (ie 'Bold' button wouldn't be active)

So, for cases where the selectionRange start is at the end of an element/node, find the next adjacent text node that actually has content in it, and move the selectionRange start there.

We can find the next non-empty text node using the native NodeIterator (which should be supported in all browsers and IE9+)