### PR TITLE
Bugfix: ignore delayed/throttled functions when editor disabled

### DIFF
--- a/spec/activate.spec.js
+++ b/spec/activate.spec.js
@@ -82,7 +82,7 @@ describe('Activate/Deactivate TestCase', function () {
             spyOn(editor, 'positionToolbarIfShown').and.callThrough(); // via: handleResize
             spyOn(editor, 'hideToolbarActions').and.callThrough(); // via: handleBlur
             editor.deactivate();
-            jasmine.clock().tick(600);
+            jasmine.clock().tick(1000); // arbitrary – must be longer than THROTTLE_INTERVAL
             expect(editor.positionToolbarIfShown).not.toHaveBeenCalled();
             expect(editor.hideToolbarActions).not.toHaveBeenCalled();
         });

--- a/spec/delay.spec.js
+++ b/spec/delay.spec.js
@@ -1,0 +1,43 @@
+/*global MediumEditor, describe, it, expect, spyOn, jasmine, fireEvent,
+         afterEach, beforeEach, selectElementContents, runs, waitsFor,
+         tearDown */
+
+describe('Delay TestCase', function () {
+    'use strict';
+
+    beforeEach(function () {
+        this.el = document.createElement('div');
+        this.el.className = 'editor';
+        this.el.textContent = 'lore ipsum';
+        document.body.appendChild(this.el);
+        jasmine.clock().install();
+    });
+
+    afterEach(function () {
+        jasmine.clock().uninstall();
+        tearDown(this.el);
+    });
+
+    it('should call function after delay', function() {
+        var editor, spy;
+
+        editor = new MediumEditor('.editor', {delay: 100});
+        spy = jasmine.createSpy('spy');
+        editor.delay(spy);
+        jasmine.clock().tick(50);
+        expect(spy).not.toHaveBeenCalled();
+        jasmine.clock().tick(150);
+        expect(spy).toHaveBeenCalled();
+    });
+    it('should not call function if editor not active', function () {
+        var editor, spy;
+
+        editor = new MediumEditor('.editor', {delay: 1});
+        spy = jasmine.createSpy('spy');
+
+        editor.deactivate();
+        editor.delay(spy);
+        jasmine.clock().tick(500);
+        expect(spy).not.toHaveBeenCalled();
+    });
+});

--- a/spec/delay.spec.js
+++ b/spec/delay.spec.js
@@ -37,7 +37,7 @@ describe('Delay TestCase', function () {
 
         editor.deactivate();
         editor.delay(spy);
-        jasmine.clock().tick(500);
+        jasmine.clock().tick(100);
         expect(spy).not.toHaveBeenCalled();
     });
 });

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -39,8 +39,8 @@ else if (typeof define === 'function' && define.amd) {
     // https://github.com/jashkenas/underscore
     function throttle(func, wait) {
         var THROTTLE_INTERVAL = 50,
-            context, 
-            args, 
+            context,
+            args,
             result,
             timeout = null,
             previous = 0,
@@ -278,6 +278,15 @@ else if (typeof define === 'function' && define.amd) {
             }
         },
 
+        delay: function(fn) {
+            var self = this;
+            setTimeout(function() {
+                if (self.isActive) {
+                    fn();
+                }
+            }, this.options.delay);
+        },
+
         removeAllEvents: function() {
             var e = this.events.pop();
             while(e) {
@@ -293,7 +302,9 @@ else if (typeof define === 'function' && define.amd) {
             // - It will be called when the browser is resizing, which can fire many times very quickly
             // - For some event (like resize) a slight lag in UI responsiveness is OK and provides performance benefits
             this.handleResize = throttle(function() {
-                self.positionToolbarIfShown();
+                if (self.isActive) {
+                    self.positionToolbarIfShown();
+                }
             });
 
             // handleBlur is throttled because:
@@ -301,7 +312,7 @@ else if (typeof define === 'function' && define.amd) {
             // - We want a slight delay so that other events in the stack can run, some of which may
             //   prevent the toolbar from being hidden (via this.keepToolbarAlive).
             this.handleBlur = throttle(function() {
-                if ( !self.keepToolbarAlive ) {
+                if (self.isActive && !self.keepToolbarAlive) {
                     self.hideToolbarActions();
                 }
             });
@@ -714,7 +725,7 @@ else if (typeof define === 'function' && define.amd) {
                 this.anchorForm = this.toolbar.querySelector('.medium-editor-toolbar-form-anchor');
                 this.anchorInput = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-input');
                 this.anchorTarget = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-target');
-                this.anchorButton = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-button');   
+                this.anchorButton = this.anchorForm.querySelector('input.medium-editor-toolbar-anchor-button');
             }
             return this;
         },
@@ -1235,9 +1246,9 @@ else if (typeof define === 'function' && define.amd) {
             this.keepToolbarAlive = false;
             // Using setTimeout + options.delay because:
             // We will actually be displaying the toolbar, which should be controlled by options.delay
-            setTimeout(function () {
+            this.delay(function () {
                 self.showToolbar();
-            }, this.options.delay);
+            });
         },
 
         saveSelection: function() {
@@ -1464,12 +1475,12 @@ else if (typeof define === 'function' && define.amd) {
                 sel.addRange(range);
                 // Using setTimeout + options.delay because:
                 // We may actually be displaying the anchor preview, which should be controlled by options.delay
-                setTimeout(function () {
+                this.delay(function () {
                     if (self.activeAnchor) {
                         self.showAnchorForm(self.activeAnchor.href);
                     }
                     self.keepToolbarAlive = false;
-                }, this.options.delay);
+                });
 
             }
 
@@ -1504,11 +1515,11 @@ else if (typeof define === 'function' && define.amd) {
                 // Using setTimeout + options.delay because:
                 // - We're going to show the anchor preview according to the configured delay
                 //   if the mouse has not left the anchor tag in that time
-                setTimeout(function () {
+                this.delay(function () {
                     if (overAnchor) {
                         self.showAnchorPreview(e.target);
                     }
-                }, this.options.delay);
+                });
             }
         },
 


### PR DESCRIPTION
Currently, calling `deactivate()` when there's something waiting to be called because of `setTimeout()` or `throttle()` can lead to exceptions, because most methods assume the editor is active at the time of calling. This can lead to errors like:
```
Uncaught TypeError: Cannot read property 'classList' of undefined
    MediumEditor.showAnchorPreview (anonymous function)
```
This PR makes all async delay/throttle logic check `isActive` before calling the function.