### PR TITLE
Improve placeholders and elements

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -49,13 +49,38 @@ describe('Initialization TestCase', function () {
         it('should allow a list of html elements as parameters', function () {
             var elements = document.querySelectorAll('span'),
                 editor = new MediumEditor(elements);
-            expect(editor.elements).toBe(elements);
+            expect(editor.elements.length).toEqual(elements.length);
         });
 
         it('should allow a single element as parameter', function () {
             var element = document.querySelector('span'),
                 editor = new MediumEditor(element);
             expect(editor.elements).toEqual([element]);
+        });
+
+        it('should always initalize elements as an Array', function() {
+            var nodeList = document.querySelectorAll('span'),
+                node = document.querySelector('span'),
+                editor = new MediumEditor(nodeList);
+
+            // nodeList is a NodeList, similar to an array but not of the same type
+            expect(editor.elements.length).toEqual(nodeList.length);
+            expect(typeof editor.elements).not.toBe(typeof nodeList);
+            editor.deactivate();
+
+            editor = new MediumEditor('span');
+            expect(editor.elements.length).toEqual(nodeList.length);
+            editor.deactivate();
+
+            editor = new MediumEditor(node);
+            expect(editor.elements.length).toEqual(1);
+            expect(editor.elements[0]).toBe(node);
+            editor.deactivate();
+
+            editor = new MediumEditor();
+            expect(editor.elements).not.toBe(null);
+            expect(editor.elements.length).toBe(0);
+            editor.deactivate();
         });
     });
 

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -363,7 +363,7 @@ else if (typeof define === 'function' && define.amd) {
 
                         // Activate the placeholder
                         if (!self.options.disablePlaceholders) {
-                            self.placeholderWrapper(self.elements[0], e);
+                            self.placeholderWrapper(e, self.elements[0]);
                         }
 
                         // Hide the toolbar after a small delay so we can prevent this on toolbar click
@@ -374,21 +374,6 @@ else if (typeof define === 'function' && define.amd) {
             // Hide the toolbar when focusing outside of the editor.
             this.on(document.body, 'click', blurFunction, true);
             this.on(document.body, 'focus', blurFunction, true);
-
-            return this;
-        },
-
-        bindKeypress: function(i) {
-            if (this.options.disablePlaceholders) {
-                return this;
-            }
-
-            var self = this;
-
-            // Set up the keypress events
-            this.on(this.elements[i], 'keypress', function(event){
-                self.placeholderWrapper(this,event);
-            });
 
             return this;
         },
@@ -428,9 +413,7 @@ else if (typeof define === 'function' && define.amd) {
                 this.bindReturn(i)
                     .bindTab(i)
                     .bindBlur(i)
-                    .bindClick(i)
-                    .bindKeypress(i);
-
+                    .bindClick(i);
             }
 
             return this;
@@ -438,7 +421,6 @@ else if (typeof define === 'function' && define.amd) {
 
         // Two functions to handle placeholders
         activatePlaceholder:  function (el) {
-
             if (!(el.querySelector('img')) &&
                     !(el.querySelector('blockquote')) &&
                     el.textContent.replace(/^\s+|\s+$/g, '') === '') {
@@ -446,9 +428,10 @@ else if (typeof define === 'function' && define.amd) {
                 el.classList.add('medium-editor-placeholder');
             }
         },
-        placeholderWrapper: function (el, e) {
+        placeholderWrapper: function (evt, el) {
+            el = el || evt.target;
             el.classList.remove('medium-editor-placeholder');
-            if (e.type !== 'keypress') {
+            if (evt.type !== 'keypress') {
                 this.activatePlaceholder(el);
             }
         },
@@ -1716,29 +1699,14 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         setPlaceholders: function () {
-            if (this.options.disablePlaceholders) {
-                return this;
+            if (!this.options.disablePlaceholders && this.elements && this.elements.length) {
+                this.elements.forEach(function(el) {
+                    this.activatePlaceholder(el);
+                    this.on(el, 'blur', this.placeholderWrapper.bind(this));
+                    this.on(el, 'keypress', this.placeholderWrapper.bind(this));
+                }.bind(this));
             }
 
-            var i,
-                activatePlaceholder = function (el) {
-                    if (!(el.querySelector('img')) &&
-                            !(el.querySelector('blockquote')) &&
-                            el.textContent.replace(/^\s+|\s+$/g, '') === '') {
-                        el.classList.add('medium-editor-placeholder');
-                    }
-                },
-                placeholderWrapper = function (e) {
-                    this.classList.remove('medium-editor-placeholder');
-                    if (e.type !== 'keypress') {
-                        activatePlaceholder(this);
-                    }
-                };
-            for (i = 0; i < this.elements.length; i += 1) {
-                activatePlaceholder(this.elements[i]);
-                this.on(this.elements[i], 'blur', placeholderWrapper);
-                this.on(this.elements[i], 'keypress', placeholderWrapper);
-            }
             return this;
         },
 

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -310,7 +310,6 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         initElements: function () {
-            this.updateElementList();
             var i,
                 addToolbar = false;
             for (i = 0; i < this.elements.length; i += 1) {
@@ -337,15 +336,19 @@ else if (typeof define === 'function' && define.amd) {
         },
 
         setElementSelection: function (selector) {
-            this.elementSelection = selector;
-            this.updateElementList();
-        },
-
-        updateElementList: function () {
-            this.elements = typeof this.elementSelection === 'string' ? this.options.ownerDocument.querySelectorAll(this.elementSelection) : this.elementSelection;
-            if (this.elements.nodeType === 1) {
-                this.elements = [this.elements];
+            if (!selector) {
+                selector = [];
             }
+            // If string, use as query selector
+            if (typeof selector === 'string') {
+                selector = this.options.ownerDocument.querySelectorAll(selector);
+            }
+            // If element, put into array
+            if (isElement(selector)) {
+                selector = [selector];
+            }
+            // Convert NodeList (or other array like object) into an array
+            this.elements = Array.prototype.slice.apply(selector);
         },
 
         bindBlur: function(i) {


### PR DESCRIPTION
This will remove code paths that were always running twice, which included redundantly attaching event handlers.  This also improves some code and gets ride of some duplication around elements and placeholders.

+ Ensure `this.elements` is always initialized to an array (never a node, NodeList, or null)
+ Remove unneeded call to `this.updateElementList()`
+ Remove unneeded `bindKeyPress` function (`setPlaceholders()` does the same thing and is always called during initalization)
+ Ensure all placeholder code is using the same `activatePlaceholder()` and `placeholderWrapper()` function
+ Begin using `Array.prototype.forEach` and `Function.prototype.bind` 
  + [Array.prototype.forEach](http://kangax.github.io/compat-table/es5/#Array.prototype.forEach) and [Function.prototype.bind](http://kangax.github.io/compat-table/es5/#Function.prototype.bind) are both part of ECMAScript 5, which is implemented by all of the browsers medium-editor supports