### PR TITLE
Newlines were not being respected on content placeholders

### DIFF
--- a/dist/css/medium-editor.css
+++ b/dist/css/medium-editor.css
@@ -167,4 +167,5 @@
     top: 0;
     left: 0;
     content: attr(data-placeholder) !important;
-    font-style: italic; }
+    font-style: italic;
+    white-space: pre; }

--- a/src/sass/medium-editor.scss
+++ b/src/sass/medium-editor.scss
@@ -150,5 +150,6 @@
         left: 0;
         content: attr(data-placeholder) !important;
         font-style: italic;
+        white-space: pre;
     }
 }


### PR DESCRIPTION
If you have newlines in your placeholder attribute like so:
![screen shot 2015-01-26 at 6 48 53 pm](https://cloud.githubusercontent.com/assets/245680/5910787/ff2703aa-a58b-11e4-8c56-13a17df8fffe.png)

The newlines aren't respected:
![screen shot 2015-01-26 at 6 48 29 pm](https://cloud.githubusercontent.com/assets/245680/5910778/f128c036-a58b-11e4-96e8-c9b7a81e74e3.png)

This change now has the placeholder display newlines:
![screen shot 2015-01-26 at 6 47 46 pm](https://cloud.githubusercontent.com/assets/245680/5910779/f131fcb4-a58b-11e4-9164-34e94106a789.png)
