### PR TITLE
specify npm registry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "wysiwyg",
     "rich-text"
   ],
+  "publishConfig": {
+    "registry": "http://registry.npmjs.org/"
+  },
   "license": "THE BEER-WARE LICENSE",
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
@daviferreira –  what do you think of this? feel free to reject, just wondering.

by default, npm modules are published-to and fetched-from
the `http://registry.npmjs.com` registry.

however, it is possible to have different registries set up for NPM on a
system or per-repository/per-directory basis.

For example, some people have a system-level npm config that points their registry to `http://registry.npmjs.eu`. This is good for fetching packages if you're a developer in EU, but bad for publishing, because you cannot publish to the european mirror (it is read only). You can read an article about that here: http://shapeshed.com/using-the-european-npm-mirror/

this commit ensures that developers are publishing to the canonical
registry for this project (`http://registry.npmjs.org`).