### PR TITLE
Fix bug in getSelectedParentElement + tests in browsers

### DIFF
--- a/spec/activate.spec.js
+++ b/spec/activate.spec.js
@@ -1,6 +1,6 @@
 /*global MediumEditor, describe, it, expect, spyOn, jasmine, fireEvent,
          afterEach, beforeEach, selectElementContents, runs, waitsFor,
-         tearDown, xit */
+         tearDown, xit, selectElementContentsAndFire */
 
 describe('Activate/Deactivate TestCase', function () {
     'use strict';
@@ -109,18 +109,16 @@ describe('Activate/Deactivate TestCase', function () {
 
             spyOn(editor, 'hideToolbarActions').and.callThrough(); // via: handleBlur
 
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'click');
+            selectElementContentsAndFire(editor.elements[0], { eventToFire: 'click' });
             jasmine.clock().tick(51);
             expect(editor.hideToolbarActions).not.toHaveBeenCalled();
 
-            selectElementContents(editor.elements[1]);
-            fireEvent(editor.elements[1], 'click');
+            selectElementContentsAndFire(editor.elements[1], { eventToFire: 'click' });
             jasmine.clock().tick(51);
             expect(editor.hideToolbarActions).not.toHaveBeenCalled();
 
             selectElementContents(editor.elements[2]);
-            fireEvent(editor.elements[2], 'click');
+            selectElementContentsAndFire(editor.elements[2], { eventToFire: 'click' });
             jasmine.clock().tick(51);
             expect(editor.hideToolbarActions).not.toHaveBeenCalled();
 
@@ -143,6 +141,7 @@ describe('Activate/Deactivate TestCase', function () {
             editor.deactivate();
 
             jasmine.clock().tick(501);
+            expect(true).toBe(true);
         });
     });
 });

--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -23,7 +23,8 @@ describe('Anchor Preview TestCase', function () {
             var editor = new MediumEditor('.editor', {
                 delay: 200
             }),
-                sel = window.getSelection();
+                sel = window.getSelection(),
+                nextRange;
 
             // show preview
             spyOn(MediumEditor.prototype, 'showAnchorPreview').and.callThrough();
@@ -48,8 +49,10 @@ describe('Anchor Preview TestCase', function () {
 
             // selecting other text should close the toolbar
             spyOn(MediumEditor.prototype, 'hideToolbarActions').and.callThrough();
+            nextRange = document.createRange();
+            nextRange.selectNodeContents(document.getElementById('another-element'));
             sel.removeAllRanges();
-            sel.addRange(document.createRange().selectNodeContents(document.getElementById('another-element')));
+            sel.addRange(nextRange);
             fireEvent(document.documentElement, 'mouseup');
             jasmine.clock().tick(200);
             expect(editor.hideToolbarActions).toHaveBeenCalled();

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -1,6 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, selectElementContents,
-         jasmine, fireEvent, console, tearDown*/
+         jasmine, fireEvent, console, tearDown,
+         selectElementContentsAndFire */
 
 describe('Anchor Button TestCase', function () {
     'use strict';
@@ -23,8 +24,7 @@ describe('Anchor Button TestCase', function () {
             spyOn(MediumEditor.prototype, 'showAnchorForm').and.callThrough();
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="a"]');
             fireEvent(button, 'click');
@@ -37,8 +37,7 @@ describe('Anchor Button TestCase', function () {
             spyOn(MediumEditor.prototype, 'showToolbarActions').and.callThrough();
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="a"]');
             editor.anchorForm.style.display = 'block';
@@ -53,8 +52,7 @@ describe('Anchor Button TestCase', function () {
             this.el.innerHTML = '<a href="#">link</a>';
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="a"]');
             fireEvent(button, 'click');

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -1,6 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, selectElementContents,
-         jasmine, fireEvent, tearDown*/
+         jasmine, fireEvent, tearDown,
+         selectElementContentsAndFire */
 
 describe('Buttons TestCase', function () {
     'use strict';
@@ -29,8 +30,7 @@ describe('Buttons TestCase', function () {
             var button,
                 editor = new MediumEditor('.editor');
             this.el.innerHTML = '<b>lorem ipsum</b>';
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="b"]');
             expect(button.className).toContain('medium-editor-button-active');
@@ -45,8 +45,7 @@ describe('Buttons TestCase', function () {
         it('should set active class on click', function () {
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="b"]');
             fireEvent(button, 'click');
@@ -57,8 +56,7 @@ describe('Buttons TestCase', function () {
             spyOn(MediumEditor.prototype, 'checkSelection');
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="b"]');
             editor.selection = undefined;
@@ -70,8 +68,7 @@ describe('Buttons TestCase', function () {
             this.el.innerHTML = '<b>lorem ipsum</b>';
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="b"]');
             expect(button.className).toContain('medium-editor-button-active');
@@ -83,8 +80,7 @@ describe('Buttons TestCase', function () {
             spyOn(MediumEditor.prototype, 'execAction');
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="b"]');
             fireEvent(button, 'click');
@@ -95,8 +91,7 @@ describe('Buttons TestCase', function () {
             spyOn(document, 'execCommand').and.callThrough();
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="i"]');
             fireEvent(button, 'click');
@@ -108,8 +103,7 @@ describe('Buttons TestCase', function () {
             spyOn(MediumEditor.prototype, 'execAction');
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="b"]');
             fireEvent(button, 'click');
@@ -120,8 +114,7 @@ describe('Buttons TestCase', function () {
             spyOn(MediumEditor.prototype, 'triggerAnchorAction');
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="a"]');
             fireEvent(button, 'click');
@@ -138,8 +131,7 @@ describe('Buttons TestCase', function () {
             spyOn(MediumEditor.prototype, 'execFormatBlock');
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="h3"]');
             fireEvent(button, 'click');
@@ -150,8 +142,7 @@ describe('Buttons TestCase', function () {
             this.el.innerHTML = '<p><b>lorem ipsum</b></p>';
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="h3"]');
             fireEvent(button, 'click');
@@ -162,8 +153,7 @@ describe('Buttons TestCase', function () {
             this.el.innerHTML = '<h3><b>lorem ipsum</b></h3>';
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContents(editor.elements[0]);
-            fireEvent(editor.elements[0], 'mouseup');
+            selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="h3"]');
             fireEvent(button, 'click');

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -23,6 +23,12 @@ function fireEvent (element, event, keyCode, ctrlKey, target, relatedTarget) {
    }
 }
 
+function selectElementContentsAndFire(el, options) {
+    options = options || {};
+    selectElementContents(el, options);
+    fireEvent(el, options.eventToFire || 'mouseup');
+}
+
 function selectElementContents(el, options) {
     options = options || {};
 

--- a/spec/resize.spec.js
+++ b/spec/resize.spec.js
@@ -1,6 +1,6 @@
 /*global MediumEditor, describe, it, expect,
          afterEach, beforeEach, fireEvent, spyOn,
-         selectElementContents, jasmine, tearDown,
+         selectElementContentsAndFire, jasmine, tearDown,
          console, xit*/
 
 describe('Resize TestCase', function () {
@@ -21,14 +21,14 @@ describe('Resize TestCase', function () {
 
     it('should reset toolbar position on window resize', function () {
         var editor = new MediumEditor('.editor');
-        selectElementContents(editor.elements[0]);
-        fireEvent(editor.elements[0], 'mouseup');
+        selectElementContentsAndFire(editor.elements[0]);
         jasmine.clock().tick(101);
         expect(editor.toolbar.className.indexOf('active') > -1).toBe(true);
         spyOn(editor, 'setToolbarPosition');
         fireEvent(window, 'resize');
         jasmine.clock().tick(101);
         expect(editor.setToolbarPosition).toHaveBeenCalled();
+        editor.deactivate();
     });
 
     // I believe some other test is breaking this one, it passes when runs alone

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -1,6 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, fireEvent, waits,
-         jasmine, selectElementContents, tearDown*/
+         jasmine, selectElementContents, tearDown,
+         selectElementContentsAndFire */
 
 describe('Selection TestCase', function () {
     'use strict';
@@ -10,6 +11,7 @@ describe('Selection TestCase', function () {
         this.el.className = 'editor';
         this.el.innerHTML = 'lorem ipsum';
         document.body.appendChild(this.el);
+        jasmine.clock().install();
     });
 
     afterEach(function () {
@@ -19,7 +21,6 @@ describe('Selection TestCase', function () {
 
     describe('CheckSelection', function () {
         it('should check for selection on mouseup event', function () {
-            jasmine.clock().install();
             spyOn(MediumEditor.prototype, 'checkSelection');
             var editor = new MediumEditor('.editor');
             fireEvent(editor.elements[0], 'mouseup');
@@ -28,7 +29,6 @@ describe('Selection TestCase', function () {
         });
 
         it('should check for selection on keyup', function () {
-            jasmine.clock().install();
             spyOn(MediumEditor.prototype, 'checkSelection');
             var editor = new MediumEditor('.editor');
             fireEvent(editor.elements[0], 'keyup');
@@ -62,10 +62,8 @@ describe('Selection TestCase', function () {
 
             it('should show the toolbar when something is selected', function () {
                 var editor = new MediumEditor('.editor');
-                jasmine.clock().install();
                 expect(editor.toolbar.classList.contains('medium-editor-toolbar-active')).toBe(false);
-                selectElementContents(this.el);
-                editor.checkSelection();
+                selectElementContentsAndFire(this.el);
                 jasmine.clock().tick(501);
                 expect(editor.toolbar.classList.contains('medium-editor-toolbar-active')).toBe(true);
             });
@@ -75,8 +73,8 @@ describe('Selection TestCase', function () {
                 spyOn(MediumEditor.prototype, 'setToolbarButtonStates').and.callThrough();
                 spyOn(MediumEditor.prototype, 'showToolbarActions').and.callThrough();
                 var editor = new MediumEditor('.editor');
-                selectElementContents(this.el);
-                editor.checkSelection();
+                selectElementContentsAndFire(this.el);
+                jasmine.clock().tick(51);
                 expect(editor.setToolbarPosition).toHaveBeenCalled();
                 expect(editor.setToolbarButtonStates).toHaveBeenCalled();
                 expect(editor.showToolbarActions).toHaveBeenCalled();
@@ -89,8 +87,8 @@ describe('Selection TestCase', function () {
                     updateOnEmptySelection: true
                 });
 
-                selectElementContents(this.el, { collapse: 'toStart' });
-                editor.checkSelection();
+                selectElementContentsAndFire(this.el, { collapse: 'toStart' });
+                jasmine.clock().tick(51);
 
                 expect(editor.setToolbarButtonStates).toHaveBeenCalled();
             });

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1384,7 +1384,7 @@ if (typeof module === 'object') {
         getSelectedParentElement: function () {
             var selectedParentElement = null,
                 range = this.selectionRange;
-            if (this.rangeSelectsSingleNode(range)) {
+            if (this.rangeSelectsSingleNode(range) && range.startContainer.childNodes[range.startOffset].nodeType !== 3) {
                 selectedParentElement = range.startContainer.childNodes[range.startOffset];
             } else if (range.startContainer.nodeType === 3) {
                 selectedParentElement = range.startContainer.parentNode;


### PR DESCRIPTION
+ Create a test helper method `selectElementContentsAndFire()` for selecting elements and triggering medium-editor to update based on that selection
+ Fix a bug in `getSelectedParentElement()` where a text-node could returned, which is not a parent of any elements.  This was causing certain buttons to show the 'opposite' of whether they should be active or not based on the selection
+ Fix all tests that were broken when running in chrome
+ General test cleanup and consolidation