### PR TITLE
Fix Browser Tests in Non-Webkit-based Browsers

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -1,7 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, selectElementContents,
          jasmine, fireEvent, console, tearDown,
-         selectElementContentsAndFire */
+         selectElementContentsAndFire, xit */
 
 describe('Anchor Button TestCase', function () {
     'use strict';
@@ -94,32 +94,32 @@ describe('Anchor Button TestCase', function () {
         it('should add http:// if need be and checkLinkFormat option is set to true', function () {
             var editor = new MediumEditor('.editor', {
                 checkLinkFormat: true
-            }),
-                input = editor.anchorForm.querySelector('input');
-            selectElementContents(editor.elements[0]);
-            input.value = 'test.com';
-            editor.createLink(input);
+            });
+            selectElementContentsAndFire(editor.elements[0]);
+            editor.showAnchorForm('test.com');
+            fireEvent(editor.anchorForm.querySelector('a.medium-editor-toobar-save'), 'click');
+
             expect(editor.elements[0].querySelector('a').href).toBe('http://test.com/');
         });
         it('should not change protocol when a valid one is included', function () {
             var editor = new MediumEditor('.editor', {
                 checkLinkFormat: true
             }),
-                input = editor.anchorForm.querySelector('input'),
                 validUrl = 'mailto:test.com';
-            selectElementContents(editor.elements[0]);
-            input.value = validUrl;
-            editor.createLink(input);
+            selectElementContentsAndFire(editor.elements[0]);
+            editor.showAnchorForm(validUrl);
+            fireEvent(editor.anchorForm.querySelector('a.medium-editor-toobar-save'), 'click');
+
             expect(editor.elements[0].querySelector('a').href).toBe(validUrl);
         });
         it('should add target="_blank" when respective option is set to true', function () {
             var editor = new MediumEditor('.editor', {
                 targetBlank: true
-            }),
-                input = editor.anchorForm.querySelector('input');
-            selectElementContents(editor.elements[0]);
-            input.value = 'http://test.com';
-            editor.createLink(input);
+            });
+            selectElementContentsAndFire(editor.elements[0]);
+            editor.showAnchorForm('http://test.com');
+            fireEvent(editor.anchorForm.querySelector('a.medium-editor-toobar-save'), 'click');
+
             expect(editor.elements[0].querySelector('a').target).toBe('_blank');
         });
         it('should create a button when user selects this option and presses enter', function () {
@@ -145,15 +145,6 @@ describe('Anchor Button TestCase', function () {
 
             fireEvent(input, 'keyup', 13);
             expect(editor.createLink).toHaveBeenCalledWith(input, '_self', 'btn btn-default');
-        });
-        it('should set class when respective option is set to true and checkbox is checked', function () {
-            var editor = new MediumEditor('.editor'),
-                input = editor.anchorForm.querySelector('input');
-
-            selectElementContents(editor.elements[0]);
-            input.value = 'http://test.com';
-
-            editor.createLink(input, '_blank', 'btn btn-default');
             expect(editor.elements[0].querySelector('a').classList.contains('btn')).toBe(true);
             expect(editor.elements[0].querySelector('a').classList.contains('btn-default')).toBe(true);
         });

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -96,7 +96,8 @@ describe('Buttons TestCase', function () {
             button = editor.toolbar.querySelector('[data-element="i"]');
             fireEvent(button, 'click');
             expect(document.execCommand).toHaveBeenCalled();
-            expect(this.el.innerHTML).toBe('<i>lorem ipsum</i>');
+            // IE won't generate an `<i>` tag here. it generates an `<em>`:
+            expect(this.el.innerHTML).toMatch(/(<i>|<em>)lorem ipsum(<\/i>|<\/em>)/);
         });
 
         it('should execute the button action', function () {

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -153,7 +153,7 @@ describe('Buttons TestCase', function () {
             this.el.innerHTML = '<h3><b>lorem ipsum</b></h3>';
             var button,
                 editor = new MediumEditor('.editor');
-            selectElementContentsAndFire(editor.elements[0]);
+            selectElementContentsAndFire(editor.elements[0].firstChild);
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="h3"]');
             fireEvent(button, 'click');

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -147,7 +147,10 @@ describe('Buttons TestCase', function () {
             jasmine.clock().tick(1);
             button = editor.toolbar.querySelector('[data-element="h3"]');
             fireEvent(button, 'click');
-            expect(this.el.innerHTML).toBe('<h3><b>lorem ipsum</b></h3>');
+            // depending on the styling you have,
+            // IE might strip the <b> out when it applies the H3 here.
+            // so, make the <b> match optional in the output:
+            expect(this.el.innerHTML).toMatch(/<h3>(<b>)?lorem ipsum(<\/b>)?<\/h3>/);
         });
 
         it('should get back to a p element if parent element is the same as the action', function () {

--- a/spec/cleanup-paste.spec.js
+++ b/spec/cleanup-paste.spec.js
@@ -61,9 +61,8 @@ describe('Clean pasted HTML', function () {
     });
 
     it('Inline rich-text pastes', function () {
-        var i, range,
+        var i,
             editorEl = this.el,
-            sel = window.getSelection(),
             editor = new MediumEditor('.editor', {
                 delay: 200,
                 forcePlainText: false,
@@ -85,16 +84,19 @@ describe('Clean pasted HTML', function () {
         for (i = 0; i < tests.length; i += 1) {
 
             // move caret to editor
-            editorEl.innerHTML = 'Before <span id="editor-inner">&nbsp</span> after.';
+            editorEl.innerHTML = 'Before&nbsp;<span id="editor-inner">&nbsp;</span>&nbsp;after.';
 
-            range = document.createRange();
-            range.selectNodeContents(document.getElementById('editor-inner'));
-            sel.removeAllRanges();
-            sel.addRange(range);
+            selectElementContents(document.getElementById('editor-inner'));
 
             editor.cleanPaste(tests[i].paste);
             jasmine.clock().tick(100);
-            expect(editorEl.innerHTML).toEqual('Before&nbsp;' + tests[i].output + '&nbsp;after.');
+            if (editorEl.innerHTML.indexOf('<span id="editor-inner">') !== -1) {
+                // Firefox and IE: doing an insertHTML while this <span> is selected results in the html being inserted inside of the span
+                expect(editorEl.innerHTML).toEqual('Before&nbsp;<span id="editor-inner">' + tests[i].output + '</span>&nbsp;after.');
+            } else {
+                // Chrome, Safari, and our test suite: doing an insertHTML while this <span> is selected results in the span being replaced completely
+                expect(editorEl.innerHTML).toEqual('Before&nbsp;' + tests[i].output + '&nbsp;after.');
+            }
         }
 
     });

--- a/spec/cleanup-paste.spec.js
+++ b/spec/cleanup-paste.spec.js
@@ -1,6 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, selectElementContents,
-         jasmine, fireEvent, console, tearDown*/
+         jasmine, fireEvent, console, tearDown,
+         selectElementContentsAndFire */
 
 describe('Clean pasted HTML', function () {
     'use strict';
@@ -20,9 +21,8 @@ describe('Clean pasted HTML', function () {
     });
 
     it('Multi-line rich-text pastes', function () {
-        var i, range,
+        var i,
             editorEl = this.el,
-            sel = window.getSelection(),
             editor = new MediumEditor('.editor', {
                 delay: 200,
                 forcePlainText: false,
@@ -51,10 +51,7 @@ describe('Clean pasted HTML', function () {
             // move caret to editor
             editorEl.innerHTML = '<span id="editor-inner">&nbsp</span>';
 
-            range = document.createRange();
-            range.selectNodeContents(document.getElementById('editor-inner'));
-            sel.removeAllRanges();
-            sel.addRange(range);
+            selectElementContentsAndFire(editorEl);
 
             editor.cleanPaste(tests[i].paste);
             jasmine.clock().tick(100);

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -22,6 +22,7 @@ describe('Events TestCase', function () {
         it('should bind listener', function () {
             var el, editor, spy;
             el = document.createElement('div');
+            el = document.body.appendChild(el);
             spy = jasmine.createSpy('handler');
             editor = new MediumEditor('.editor');
             editor.on(el, 'click', spy);

--- a/spec/exploits.spec.js
+++ b/spec/exploits.spec.js
@@ -50,7 +50,7 @@ describe('Exploits', function () {
         editorEl.innerHTML = '<span id="editor-inner">&nbsp</span>';
 
         range = document.createRange();
-        range.selectNodeContents(document.getElementById('editor-inner'));
+        range.selectNodeContents(editorEl);
         sel.removeAllRanges();
         sel.addRange(range);
 

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -66,14 +66,24 @@ describe('Placeholder TestCase', function () {
     it('should add the default placeholder text when data-placeholder is not present', function () {
         var editor = new MediumEditor('.editor'),
             placeholder = window.getComputedStyle(editor.elements[0], ':after').getPropertyValue('content');
-        expect(placeholder).toEqual("'" + editor.options.placeholder + "'");
+        if (placeholder.indexOf('attr(') === 0) {
+            // In firefox, getComputedStyle().getPropertyValue('content') can return attr() instead of what attr() evaluates to
+            expect(placeholder).toEqual('attr(data-placeholder)');
+        } else {
+            expect(placeholder).toEqual("'" + editor.options.placeholder + "'");
+        }
     });
 
     it('should use the data-placeholder when it is present', function () {
         this.el.setAttribute('data-placeholder', 'Custom placeholder');
         var editor = new MediumEditor('.editor'),
             placeholder = window.getComputedStyle(editor.elements[0], ':after').getPropertyValue('content');
-        expect(placeholder).toEqual("'Custom placeholder'");
+        if (placeholder.indexOf("attr(") === 0) {
+            // In firefox, getComputedStyle().getPropertyValue('content') can return attr() instead of what attr() evaluates to
+            expect(placeholder).toEqual("attr(data-placeholder)");
+        } else {
+            expect(placeholder).toEqual("'Custom placeholder'");
+        }
     });
 
     it('should not set placeholder for empty elements when disablePlaceholders is set to true', function () {

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -63,27 +63,31 @@ describe('Placeholder TestCase', function () {
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 
-    it('should add the default placeholder text when data-placeholder is not present', function () {
-        var editor = new MediumEditor('.editor'),
-            placeholder = window.getComputedStyle(editor.elements[0], ':after').getPropertyValue('content');
-        if (placeholder.indexOf('attr(') === 0) {
+    /*jslint regexp: true*/
+    function validatePlaceholderContent(element, expectedValue) {
+        var placeholder = window.getComputedStyle(element, ':after').getPropertyValue('content'),
+            regex = /^attr\(([^\)]+)\)$/g,
+            match = regex.exec(placeholder);
+        if (match) {
             // In firefox, getComputedStyle().getPropertyValue('content') can return attr() instead of what attr() evaluates to
-            expect(placeholder).toEqual('attr(data-placeholder)');
+            expect(match[1]).toEqual('data-placeholder');
         } else {
-            expect(placeholder).toEqual("'" + editor.options.placeholder + "'");
+            expect(placeholder).toEqual("'" + expectedValue + "'");
         }
+    }
+    /*jslint regexp: false*/
+
+    it('should add the default placeholder text when data-placeholder is not present', function () {
+        var editor = new MediumEditor('.editor');
+        validatePlaceholderContent(editor.elements[0], editor.options.placeholder);
     });
 
     it('should use the data-placeholder when it is present', function () {
-        this.el.setAttribute('data-placeholder', 'Custom placeholder');
-        var editor = new MediumEditor('.editor'),
-            placeholder = window.getComputedStyle(editor.elements[0], ':after').getPropertyValue('content');
-        if (placeholder.indexOf("attr(") === 0) {
-            // In firefox, getComputedStyle().getPropertyValue('content') can return attr() instead of what attr() evaluates to
-            expect(placeholder).toEqual("attr(data-placeholder)");
-        } else {
-            expect(placeholder).toEqual("'Custom placeholder'");
-        }
+        var editor,
+            placeholderText = 'Custom placeholder';
+        this.el.setAttribute('data-placeholder', placeholderText);
+        editor = new MediumEditor('.editor');
+        validatePlaceholderContent(editor.elements[0], placeholderText);
     });
 
     it('should not set placeholder for empty elements when disablePlaceholders is set to true', function () {

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -2095,7 +2095,7 @@ if (typeof module === 'object') {
                 }
 
             }
-            this.options.ownerDocument.execCommand('insertHTML', false, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));
+            insertHTMLCommand(this.options.ownerDocument, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));
         },
         isCommonBlock: function (el) {
             return (el && (el.tagName.toLowerCase() === 'p' || el.tagName.toLowerCase() === 'div'));

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -220,7 +220,9 @@ if (typeof module === 'object') {
         var selection, range, el, fragment, node, lastNode;
 
         if (doc.queryCommandSupported('insertHTML')) {
-            return doc.execCommand('insertHTML', false, html);
+            try {
+                return doc.execCommand('insertHTML', false, html);
+            } catch (ignore) {}
         }
 
         selection = window.getSelection();
@@ -1952,11 +1954,7 @@ if (typeof module === 'object') {
                         paragraphs = e.clipboardData.getData(dataFormatPlain).split(/[\r\n]/g);
                         for (p = 0; p < paragraphs.length; p += 1) {
                             if (paragraphs[p] !== '') {
-                                if (navigator.userAgent.match(/firefox/i) && p === 0) {
-                                    html += self.htmlEntities(paragraphs[p]);
-                                } else {
-                                    html += '<p>' + self.htmlEntities(paragraphs[p]) + '</p>';
-                                }
+                                html += '<p>' + self.htmlEntities(paragraphs[p]) + '</p>';
                             }
                         }
                         insertHTMLCommand(self.options.ownerDocument, html);

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1825,26 +1825,7 @@ if (typeof module === 'object') {
         createLink: function (input, target, buttonClass) {
             var i, event;
 
-            if (input.value.trim().length === 0) {
-                this.hideToolbarActions();
-                return;
-            }
-
-            restoreSelection.call(this, this.savedSelection);
-
-            if (this.options.checkLinkFormat) {
-                input.value = this.checkLinkFormat(input.value);
-            }
-
-            this.options.ownerDocument.execCommand('createLink', false, input.value);
-
-            if (this.options.targetBlank || target === "_blank") {
-                this.setTargetBlank();
-            }
-
-            if (buttonClass) {
-                this.setButtonClass(buttonClass);
-            }
+            this.createLinkInternal(input.value, target, buttonClass);
 
             if (this.options.targetBlank || target === "_blank" || buttonClass) {
                 event = this.options.ownerDocument.createEvent("HTMLEvents");
@@ -1857,6 +1838,29 @@ if (typeof module === 'object') {
             this.checkSelection();
             this.showToolbarActions();
             input.value = '';
+        },
+
+        createLinkInternal: function (url, target, buttonClass) {
+            if (!url || url.trim().length === 0) {
+                this.hideToolbarActions();
+                return;
+            }
+
+            restoreSelection.call(this, this.savedSelection);
+
+            if (this.options.checkLinkFormat) {
+                url = this.checkLinkFormat(url);
+            }
+
+            this.options.ownerDocument.execCommand('createLink', false, url);
+
+            if (this.options.targetBlank || target === "_blank") {
+                this.setTargetBlank();
+            }
+
+            if (buttonClass) {
+                this.setButtonClass(buttonClass);
+            }
         },
 
         positionToolbarIfShown: function () {


### PR DESCRIPTION
+ Fix all the tests that were failing when running in firefox
+ Thanks to @nchase , also fixed all the tests that were still failing in IE
+ In cases where firefox or IE are doing something very differently from other browsers, branch the test cases to keep the intent of the case without having to remove them completely