### PR TITLE
Fix showing and writing encoded links 

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -9,7 +9,11 @@ describe('Anchor Preview TestCase', function () {
         jasmine.clock().install();
         this.el = document.createElement('div');
         this.el.className = 'editor';
-        this.el.innerHTML = 'lorem <a id="test-link" href="http://test.com">ipsum</a> preview <span id="another-element">&nbsp;</span> <a id="test-empty-link" href="">ipsum</a>';
+        this.el.innerHTML = 'lorem ' +
+            '<a id="test-link" href="http://test.com">ipsum</a> ' +
+            'preview <span id="another-element">&nbsp;</span> ' +
+            '<a id="test-empty-link" href="">ipsum</a> ' +
+            '<a id="test-symbol-link" href="http://[{~#custom#~}].com"></a>';
         document.body.appendChild(this.el);
     });
 
@@ -39,7 +43,7 @@ describe('Anchor Preview TestCase', function () {
             expect(editor.showAnchorPreview).toHaveBeenCalled();
 
             // link is set in preview
-            expect(editor.anchorPreview.querySelector('i').innerHTML).toBe(document.getElementById('test-link').href);
+            expect(editor.anchorPreview.querySelector('i').innerHTML).toBe(document.getElementById('test-link').attributes.href.value);
 
             // load into editor
             spyOn(MediumEditor.prototype, 'showAnchorForm').and.callThrough();
@@ -57,6 +61,22 @@ describe('Anchor Preview TestCase', function () {
             jasmine.clock().tick(200);
             expect(editor.hideToolbarActions).toHaveBeenCalled();
 
+        });
+
+        it('Should show the unencoded link within the preview', function () {
+            var editor = new MediumEditor('.editor');
+
+            // show preview
+            editor.editorAnchorObserver({
+                target: document.getElementById('test-symbol-link')
+            });
+            fireEvent(editor.elements[0], 'mouseover', undefined, undefined, document.getElementById('test-symbol-link'));
+
+            // preview shows only after delay
+            jasmine.clock().tick(200);
+
+            // link is set in preview
+            expect(editor.anchorPreview.querySelector('i').innerHTML).toBe(document.getElementById('test-symbol-link').attributes.href.value);
         });
 
         it('Anchor form stays visible on click', function () {

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1628,7 +1628,7 @@ if (typeof module === 'object') {
                 halfOffsetWidth,
                 defaultLeft;
 
-            self.anchorPreview.querySelector('i').textContent = anchorEl.href;
+            self.anchorPreview.querySelector('i').textContent = anchorEl.attributes.href.value;
             halfOffsetWidth = self.anchorPreview.offsetWidth / 2;
             defaultLeft = self.options.diffLeft - halfOffsetWidth;
 
@@ -1727,7 +1727,7 @@ if (typeof module === 'object') {
                 // We may actually be displaying the anchor preview, which should be controlled by options.delay
                 this.delay(function () {
                     if (self.activeAnchor) {
-                        self.showAnchorForm(self.activeAnchor.href);
+                        self.showAnchorForm(self.activeAnchor.attributes.href.value);
                     }
                     self.keepToolbarAlive = false;
                 });


### PR DESCRIPTION
We're currently using ME on a platform that uses links similar to the following format... 
```html
http://{custom_domain}.com/
```
However the current anchor preview and anchor form fetch the link address by using the `href` property directly on the anchor element, the browser returns the encoded link, something like ....
```html
http://%7Bcustom_domain%7D.com/
``` 

By fetching from the attributes property instead it will return the unencoded link. 

