### PR TITLE
fix 'imageDragging: false' option.

### DIFF
--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -1035,7 +1035,7 @@ if (typeof module === 'object') {
             var self = this, i, className, onDrag, onDrop, element;
 
             if (!self.options.imageDragging) {
-                return;
+                return this;
             }
 
             className = 'medium-editor-dragover';


### PR DESCRIPTION
https://github.com/daviferreira/medium-editor/issues/412

fix chaining on 'bindDragDrop' function when 'imageDragging' is set to 'false'.