### PR TITLE
Don't use styles for detecting underline + strikethrough

### DIFF
--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -1,7 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
          afterEach, beforeEach, selectElementContents,
          jasmine, fireEvent, tearDown, console,
-         selectElementContentsAndFire */
+         selectElementContentsAndFire, xit */
 
 describe('Buttons TestCase', function () {
     'use strict';
@@ -215,7 +215,7 @@ describe('Buttons TestCase', function () {
             expect(this.el.innerHTML).toBe('lorem ipsum');
         });
 
-        it('button should be active for other cases when text is underlined', function () {
+        xit('button should be active for other cases when text is underlined', function () {
             var editor = new MediumEditor('.editor', {
                     buttons: ['underline']
                 }),
@@ -247,7 +247,7 @@ describe('Buttons TestCase', function () {
             expect(this.el.innerHTML).toBe('lorem ipsum');
         });
 
-        it('button should be active for other cases when text is strikethrough', function () {
+        xit('button should be active for other cases when text is strikethrough', function () {
             var editor = new MediumEditor('.editor', {
                     buttons: ['strikethrough']
                 }),

--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -46,10 +46,6 @@ if (typeof module === 'object') {
                 action: 'underline',
                 aria: 'underline',
                 tagNames: ['u'],
-                style: {
-                    prop: 'text-decoration',
-                    value: 'underline'
-                },
                 contentDefault: '<b><u>U</u></b>',
                 contentFA: '<i class="fa fa-underline"></i>'
             },
@@ -58,10 +54,6 @@ if (typeof module === 'object') {
                 action: 'strikethrough',
                 aria: 'strike through',
                 tagNames: ['strike'],
-                style: {
-                    prop: 'text-decoration',
-                    value: 'line-through'
-                },
                 contentDefault: '<s>A</s>',
                 contentFA: '<i class="fa fa-strikethrough"></i>'
             },


### PR DESCRIPTION
`text-decoration` is not inherited by default, so we can't use it reliably to determine if text is underlined or strikethrough in the toolbar :disappointed: 