### PR TITLE
Attempt to fix ignored unit-tests

### DIFF
--- a/spec/resize.spec.js
+++ b/spec/resize.spec.js
@@ -31,9 +31,7 @@ describe('Resize TestCase', function () {
         editor.deactivate();
     });
 
-    // I believe some other test is breaking this one, it passes when runs alone
-    // it is calling setToolbar even with no text selected
-    xit('should not call setToolbarPosition when toolbar is not visible', function () {
+    it('should not call setToolbarPosition when toolbar is not visible', function () {
         var editor = new MediumEditor('.editor');
         spyOn(editor, 'setToolbarPosition');
         fireEvent(window, 'resize');

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -275,45 +275,27 @@ describe('Toolbar TestCase', function () {
             expect(editor.toolbar.classList.contains('medium-editor-toolbar-active')).toBe(false);
         });
 
-        // jasmine 2.0 changed async tests, runs no longer exists
-        xit('should show the toolbar if it\'s text are selected even though one or more elements that has a data attr of disable-toolbar', function () {
-            var value,
-                flag,
-                element = document.createElement('div'),
-                editor = null;
+        it('should show the toolbar if it\'s text are selected even though one or more elements that has a data attr of disable-toolbar', function () {
+            var editor,
+                element = document.createElement('div');
 
-            runs(function () {
-                flag = false;
-                element.className = 'editor';
-                element.setAttribute('data-disable-toolbar', 'true');
-                this.el.innerHTML = 'lorem ipsum';
-                document.body.appendChild(element);
-                editor = new MediumEditor(document.querySelectorAll('.editor'));
-                expect(editor.elements.length).toEqual(2);
-                expect(editor.toolbar.style.display).toBe('');
-                selectElementContents(this.el);
-                editor.checkSelection();
-                setTimeout(function () {
-                    flag = true;
-                }, 500);
-            });
+            element.className = 'editor';
+            element.setAttribute('data-disable-toolbar', 'true');
+            this.el.innerHTML = 'lorem ipsum';
+            document.body.appendChild(element);
+            editor = new MediumEditor(document.querySelectorAll('.editor'));
+            expect(editor.elements.length).toEqual(3);
+            expect(editor.toolbar.style.display).toBe('');
+            selectElementContents(this.el);
+            editor.checkSelection();
 
-            // Because the toolbar appear after 100ms, waits 150ms...
-            waitsFor(function () {
-                value = value + 1; // value += 1 is not accepted by jslint (unused)
-                return flag;
-            }, 'The i value should be incremented', 500);
-
-            runs(function () {
-                expect(editor.toolbar.classList.contains('medium-editor-toolbar-active')).toBe(true);
-                // Remove the new element from the DOM
-                document.body.removeChild(element);
-            });
+            expect(editor.toolbar.classList.contains('medium-editor-toolbar-active')).toBe(true);
+            // Remove the new element from the DOM
+            document.body.removeChild(element);
 
         });
 
-        // jasmine 2.0 changed async tests, runs no longer exists
-        xit('should not try to toggle toolbar when option disabletoolbar is set to true', function () {
+        it('should not try to toggle toolbar when option disabletoolbar is set to true', function () {
             var element = document.createElement('div'),
                 editor = null;
 


### PR DESCRIPTION
I've attempted to fix the unit-tests that are ignored. All tests seem to pass &ndash; although `expect(editor.elements.length).toEqual(3);` was initially set to `2` but in having a look at the unit-test below, that also has `toEqual(3)` despite disabling the toolbar. I assume the codebase changed, and as this test was ignored, wasn't kept up-to-date.

Please correct me if I'm making a gargantuous incorrect assumption :beers: &ndash; which is quite possible.

There is [another ignored test](https://github.com/Wildhoney/medium-editor/blob/master/spec/activate.spec.js#L91) but I am unsure as to why this is ignored. I didn't want to bring it back without knowing the reason why. Although this also passes.