### PR TITLE
add figcaption exception in paragraphCreation

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -408,7 +408,7 @@ function MediumEditor(elements, options) {
                     editorElement = meSelection.getSelectionElement(self.options.contentWindow);
 
                     if (!(self.options.disableReturn || editorElement.getAttribute('data-disable-return')) &&
-                            tagName !== 'li' && !mediumEditorUtil.isListItemChild(node)) {
+                            tagName !== 'li' && tagName !== 'figcaption' && !mediumEditorUtil.isListItemChild(node)) {
                         if (!e.shiftKey) {
 
                             // paragraph creation should not be forced within a header tag


### PR DESCRIPTION
Hello,

I Added an exception in the condition of  paragraphcreation in order to use the  figcaption tag properly. 
This fix is coming form the common use of medium insert plugin and medium. 
When you set your caption with an image, the tag figcaption is used, end each enter keypres create a p tag into it :-/

Thanks 