### PR TITLE
Workaround firefox test failure

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -1,6 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
     fireEvent, afterEach, beforeEach, selectElementContents,
-    tearDown, placeCursorInsideElement, isFirefox, Util */
+    tearDown, placeCursorInsideElement, isFirefox, Util,
+    selectElementContentsAndFire */
 
 describe('Content TestCase', function () {
     'use strict';
@@ -201,10 +202,12 @@ describe('Content TestCase', function () {
 
     it('should removing paragraphs when a list is inserted inside of it', function () {
         this.el.innerHTML = '<p>lorem ipsum<ul><li>dolor</li></ul></p>';
-        var editor = new MediumEditor('.editor'),
+        var editor = new MediumEditor('.editor', {
+            buttons: ['orderedlist']
+        }),
             target = editor.elements[0].querySelector('p');
-        selectElementContents(target);
-        editor.execAction('insertorderedlist');
+        selectElementContentsAndFire(target);
+        fireEvent(editor.toolbar.getToolbarElement().querySelector('[data-action="insertorderedlist"]'), 'click');
         expect(this.el.innerHTML).toMatch(/^<ol><li>lorem ipsum(<br>)?<\/li><\/ol><ul><li>dolor<\/li><\/ul>?/);
     });
 });


### PR DESCRIPTION
This should fix #520 @daviferreira can you verify?

Yet again, firefox can throw errors in certain situations when a programmatically modified selection is followed by a call to `document.execCommand()`.

Changing a test to trigger a button click in the toolbar instead of manually calling `insertorderedlist` seems to keep firefox happy in this case.