### PR TITLE
Fix toolbars behaviour after right-click 

### DIFF
--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -154,7 +154,7 @@ var Toolbar;
             // Do not trigger checkState when mouseup fires over the toolbar
             if (event &&
                     event.target &&
-                    Util.isDescendant(this.getToolbarElement(), event.target)) {
+                    !Util.isDescendant(this.getToolbarElement(), event.target)) {
                 return false;
             }
             this.checkState();


### PR DESCRIPTION
Fixed toolbar show on all editors on page after right click on any place of page.

To reproduce you must have at least two editors on page. Both should have 
```javascript
stickyToolbar: true
staticToolbar: true
```
Then click on first editor to show toolbar. After click on second editor (first toolbar hides).
Then right click on any place of document and both toolbars should appear.

![image](https://cloud.githubusercontent.com/assets/869584/6980938/90932f76-da02-11e4-8b8d-ebb40e0af4fb.png)