### PR TITLE
When pasting text without linefeeds in FF, it was still wrapping text

### DIFF
--- a/spec/exploits.spec.js
+++ b/spec/exploits.spec.js
@@ -29,7 +29,7 @@ describe('Exploits', function () {
             test = {
                 source: 'img onerror handler',
                 paste: '><img src="x" onerror="alert(\'xss\')">',
-                output: '<p>&gt;&lt;img src="x" onerror="alert(\'xss\')"&gt;</p>'
+                output: '<span id="editor-inner">&gt;&lt;img src="x" onerror="alert(\'xss\')"&gt;</span>'
             };
 
         // mock event with clipboardData API

--- a/src/js/paste.js
+++ b/src/js/paste.js
@@ -102,17 +102,21 @@ var PasteHandler;
                 }
 
                 if (!(this.options.disableReturn || element.getAttribute('data-disable-return'))) {
-                    paragraphs = event.clipboardData.getData(dataFormatPlain).split(/[\r\n]/g);
-                    for (p = 0; p < paragraphs.length; p += 1) {
-                        if (paragraphs[p] !== '') {
-                            html += '<p>' + Util.htmlEntities(paragraphs[p]) + '</p>';
+                    paragraphs = event.clipboardData.getData(dataFormatPlain).split(/[\r\n]+/g);
+                    // If there are no \r\n in data, don't wrap in <p>
+                    if (paragraphs.length > 1) {
+                        for (p = 0; p < paragraphs.length; p += 1) {
+                            if (paragraphs[p] !== '') {
+                                html += '<p>' + Util.htmlEntities(paragraphs[p]) + '</p>';
+                            }
                         }
+                    } else {
+                        html = Util.htmlEntities(paragraphs[0]);
                     }
-                    Util.insertHTMLCommand(this.options.ownerDocument, html);
                 } else {
                     html = Util.htmlEntities(event.clipboardData.getData(dataFormatPlain));
-                    Util.insertHTMLCommand(this.options.ownerDocument, html);
                 }
+                Util.insertHTMLCommand(this.options.ownerDocument, html);
             }
         },
 


### PR DESCRIPTION
in a `<p></p>`. In FF, when pasting this text in a parapgraph, it would
result in 3 paragraphs.

For example:

This is some sample text.	// copy and paste sample right after sample

Expected:

This is some sample sample text.

Actual:

This is some sample

sample

text.