### PR TITLE
Making unwrapping of spans overridable during paste

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -129,7 +129,7 @@ describe('Initialization TestCase', function () {
                     forcePlainText: true,
                     cleanPastedHtml: false,
                     cleanAttrs: ['class', 'style', 'dir'],
-                    cleanTags: ['meta']
+                    cleanTags: ['meta', 'span']
                 }
             },
                 editor = new MediumEditor('.editor');

--- a/spec/paste.spec.js
+++ b/spec/paste.spec.js
@@ -182,7 +182,7 @@ describe('Pasting content', function () {
         it('should remove certain attributes and tags by default', function () {
             var editor = new MediumEditor('.editor');
             selectElementContents(this.el.firstChild);
-            editor.pasteHTML('<p class="some-class" style="font-weight: bold" dir="ltr"><meta name="description" content="test" />test</p>');
+            editor.pasteHTML('<p class="some-class" style="font-weight: bold" dir="ltr"><meta name="description" content="test" /><span>test</span></p>');
             expect(editor.elements[0].innerHTML).toBe('<p>test</p>');
         });
 
@@ -203,7 +203,7 @@ describe('Pasting content', function () {
                 '<div><i>test</i><meta name="description" content="test" /><b>test</b></div>',
                 {cleanTags: ['meta', 'b']}
             );
-            expect(editor.elements[0].innerHTML).toBe('<div><i>test</i></div>');
+            expect(editor.elements[0].innerHTML).toBe('<div><i>test</i>test</div>');
         });
 
         it('should respect custom clean up options passed during instantiation', function () {
@@ -216,11 +216,11 @@ describe('Pasting content', function () {
             selectElementContents(this.el.firstChild);
             editor.pasteHTML(
                 '<table class="medium-editor-table" dir="ltr" style="border: 1px solid red;"><tbody><tr><td>test</td></tr></tbody></table>' +
-                '<div><i>test</i><meta name="description" content="test" /><b>test</b></div>'
+                '<div><i>test</i><meta name="description" content="test" /><span><b>test</b></span></div>'
             );
             expect(editor.elements[0].innerHTML).toBe(
                 '<table class="medium-editor-table"><tbody><tr><td>test</td></tr></tbody></table>' +
-                '<div><i>test</i></div>'
+                '<div><i>test</i><span>test</span></div>'
             );
         });
     });

--- a/src/js/defaults/options.js
+++ b/src/js/defaults/options.js
@@ -43,7 +43,7 @@ var editorDefaults;
             forcePlainText: true,
             cleanPastedHtml: false,
             cleanAttrs: ['class', 'style', 'dir'],
-            cleanTags: ['meta']
+            cleanTags: ['meta', 'span']
         }
 
     };

--- a/src/js/paste.js
+++ b/src/js/paste.js
@@ -177,13 +177,13 @@ var PasteHandler;
             fragmentBody.innerHTML = html;
 
             this.cleanupSpans(fragmentBody);
+            this.unwrapTags(fragmentBody, options.cleanTags);
 
             elList = fragmentBody.querySelectorAll('*');
 
             for (i = 0; i < elList.length; i += 1) {
                 workEl = elList[i];
                 Util.cleanupAttrs(workEl, options.cleanAttrs);
-                Util.cleanupTags(workEl, options.cleanTags);
             }
 
             Util.insertHTMLCommand(this.options.ownerDocument, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));
@@ -224,14 +224,32 @@ var PasteHandler;
             }
         },
 
+        unwrapTags: function (container, tags) {
+            if (container && tags && tags.length) {
+                var toUnwrap = Array.prototype.slice.call(container.querySelectorAll(tags.join(","))),
+                    isCEF = function (el) {
+                        return (el && el.nodeName !== '#text' && el.getAttribute('contenteditable') === 'false');
+                    };
+                toUnwrap.forEach(function (element) {
+                    // bail if element is in contenteditable = false
+                    if (Util.traverseUp(element, isCEF)) {
+                        return false;
+                    }
+
+                    if (!element.hasChildNodes() || !element.textContent.length) {
+                        element.parentNode.removeChild(element);
+                    } else {
+                        element.parentNode.replaceChild(this.options.ownerDocument.createTextNode(element.textContent), element);
+                    }
+                }, this);
+            }
+        },
+
         cleanupSpans: function (container_el) {
             var i,
                 el,
                 new_el,
-                spans = container_el.querySelectorAll('.replace-with'),
-                isCEF = function (el) {
-                    return (el && el.nodeName !== '#text' && el.getAttribute('contenteditable') === 'false');
-                };
+                spans = container_el.querySelectorAll('.replace-with');
 
             for (i = 0; i < spans.length; i += 1) {
                 el = spans[i];
@@ -244,23 +262,6 @@ var PasteHandler;
                     new_el.innerHTML = el.innerHTML;
                 }
                 el.parentNode.replaceChild(new_el, el);
-            }
-
-            spans = container_el.querySelectorAll('span');
-            for (i = 0; i < spans.length; i += 1) {
-                el = spans[i];
-
-                // bail if span is in contenteditable = false
-                if (Util.traverseUp(el, isCEF)) {
-                    return false;
-                }
-
-                // remove empty spans, replace others with their contents
-                if (/^\s*$/.test()) {
-                    el.parentNode.removeChild(el);
-                } else {
-                    el.parentNode.replaceChild(this.options.ownerDocument.createTextNode(el.textContent), el);
-                }
             }
         }
     };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -421,14 +421,6 @@ var Util;
             });
         },
 
-        cleanupTags: function (el, tags) {
-            tags.forEach(function (tag) {
-                if (el.tagName.toLowerCase() === tag) {
-                    el.parentNode.removeChild(el);
-                }
-            });
-        },
-
         setObject: function(name, value, context){
             // summary:
             //      Set a property from a dot-separated string, such as "A.B.C"


### PR DESCRIPTION
#### Merge `cleanTags` option with span unwrapping logic during paste
* Allow ability to override unwrapping of `<span>` elements during paste
* Change `cleanTags` behavior to be unwrapping instead of just straight removing the element
  * If an element with a tag name in the `cleanTags` array is found, but it doesn't have any children, it's removed
  * Otherwise, if an element with a tag name in the `cleanTags` array is found, the `textContent` is unwrapped from the element and added as a text node

This is a proposed fix for #542 