### PR TITLE
fix BC break warn for cleanPastedHTML option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ var editor = new MediumEditor('.editable', {
     paste: {
         // This example includes the default options for paste, if nothing is passed this is what it used
         forcePlainText: true,
-        cleanPastedHtml: false,
+        cleanPastedHTML: false,
         cleanReplacements: [],
         cleanAttrs: ['class', 'style', 'dir']
         cleanTags: ['meta']
@@ -128,8 +128,8 @@ var editor = new MediumEditor('.editable', {
 ```
 
 * __forcePlainText__: Forces pasting as plain text. Default: true
-* __cleanPastedHtml__: cleans pasted content from different sources, like google docs etc. Default: false
-* __cleanReplacements__: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when __forcePlainText__ or __cleanPastedHtml__ are `true` OR when calling `cleanPaste(text)` helper method. Default: []
+* __cleanPastedHTML__: cleans pasted content from different sources, like google docs etc. Default: false
+* __cleanReplacements__: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method. Default: []
 * __cleanAttrs__: list of attributes to remove when ... default: ['class', 'style', 'dir']
 * __cleanTags__: list of element tag names to remove... default: ['meta']
 
@@ -146,7 +146,7 @@ var editor = new MediumEditor('.editable', {
     delay: 1000,
     targetBlank: true,
     paste: {
-        cleanPastedHtml: true,
+        cleanPastedHTML: true,
         cleanAttrs: ['style', 'dir']
         cleanTags: ['label', 'meta']
     }

--- a/demo/clean-paste.html
+++ b/demo/clean-paste.html
@@ -23,8 +23,10 @@
     <script>
         var editor = new MediumEditor('.editable', {
             buttonLabels: 'fontawesome',
-            cleanPastedHTML: true,
-            forcePlainText: false
+            paste: {
+                cleanPastedHTML: true,
+                forcePlainText: false
+            }
         });
     </script>
 </body>

--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -1115,7 +1115,7 @@ var editorDefaults;
 
         paste: {
             forcePlainText: true,
-            cleanPastedHtml: false,
+            cleanPastedHTML: false,
             cleanAttrs: ['class', 'style', 'dir'],
             cleanTags: ['meta']
         }
@@ -1779,9 +1779,9 @@ var PasteHandler;
     /* Paste Options:
      *
      * forcePlainText: Forces pasting as plain text. Default: true
-     * cleanPastedHtml: cleans pasted content from different sources, like google docs etc. Default: false
+     * cleanPastedHTML: cleans pasted content from different sources, like google docs etc. Default: false
      * cleanReplacements: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when
-     *                    __forcePlainText__ or __cleanPastedHtml__ are `true` OR when calling `cleanPaste(text)`
+     *                    __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)`
      *                    helper method. Default: []
      * cleanAttrs: list of attributes to remove when ... default: ['class', 'style', 'dir']
      * cleanTags: list of element tag names to remove... default: ['meta']
@@ -3458,7 +3458,7 @@ function MediumEditor(elements, options) {
             // Backwards compatability
             {
                 forcePlainText: this.options.forcePlainText, // deprecated
-                cleanPastedHtml: this.options.cleanPastedHtml, // deprecated
+                cleanPastedHTML: this.options.cleanPastedHTML, // deprecated
                 disableReturn: this.options.disableReturn,
                 targetBlank: this.options.targetBlank,
                 contentWindow: this.options.contentWindow,
@@ -3504,7 +3504,7 @@ function MediumEditor(elements, options) {
         // warn about using deprecated properties
         if (options) {
             [['forcePlainText', 'paste.forcePlainText'],
-             ['cleanPastedHtml', 'paste.cleanPastedHtml']].forEach(function (pair) {
+             ['cleanPastedHTML', 'paste.cleanPastedHTML']].forEach(function (pair) {
                 if (options.hasOwnProperty(pair[0]) && options[pair[0]] !== undefined) {
                     Util.deprecated(pair[0], pair[1]);
                 }

--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -1797,7 +1797,7 @@ var PasteHandler;
         this.base = instance;
         this.options = options;
 
-        if (this.options.forcePlainText || this.options.cleanPastedHTML) {
+        if (this.options.forcePlainText || this.options.cleanPastedHtml) {
             this.base.subscribe('editablePaste', this.handlePaste.bind(this));
         }
     };
@@ -1826,7 +1826,7 @@ var PasteHandler;
                     !event.defaultPrevented) {
                 event.preventDefault();
 
-                if (this.options.cleanPastedHTML && event.clipboardData.getData(dataFormatHTML)) {
+                if (this.options.cleanPastedHtml && event.clipboardData.getData(dataFormatHTML)) {
                     return this.cleanPaste(event.clipboardData.getData(dataFormatHTML));
                 }
 
@@ -3458,7 +3458,7 @@ function MediumEditor(elements, options) {
             // Backwards compatability
             {
                 forcePlainText: this.options.forcePlainText, // deprecated
-                cleanPastedHtml: this.options.cleanPastedHtml, // deprecated
+                cleanPastedHtml: this.options.cleanPastedHTML, // deprecated
                 disableReturn: this.options.disableReturn,
                 targetBlank: this.options.targetBlank,
                 contentWindow: this.options.contentWindow,
@@ -3504,7 +3504,7 @@ function MediumEditor(elements, options) {
         // warn about using deprecated properties
         if (options) {
             [['forcePlainText', 'paste.forcePlainText'],
-             ['cleanPastedHtml', 'paste.cleanPastedHtml']].forEach(function (pair) {
+             ['cleanPastedHTML', 'paste.cleanPastedHtml']].forEach(function (pair) {
                 if (options.hasOwnProperty(pair[0]) && options[pair[0]] !== undefined) {
                     Util.deprecated(pair[0], pair[1]);
                 }

--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -1797,7 +1797,7 @@ var PasteHandler;
         this.base = instance;
         this.options = options;
 
-        if (this.options.forcePlainText || this.options.cleanPastedHtml) {
+        if (this.options.forcePlainText || this.options.cleanPastedHTML) {
             this.base.subscribe('editablePaste', this.handlePaste.bind(this));
         }
     };
@@ -1826,7 +1826,7 @@ var PasteHandler;
                     !event.defaultPrevented) {
                 event.preventDefault();
 
-                if (this.options.cleanPastedHtml && event.clipboardData.getData(dataFormatHTML)) {
+                if (this.options.cleanPastedHTML && event.clipboardData.getData(dataFormatHTML)) {
                     return this.cleanPaste(event.clipboardData.getData(dataFormatHTML));
                 }
 
@@ -3458,7 +3458,7 @@ function MediumEditor(elements, options) {
             // Backwards compatability
             {
                 forcePlainText: this.options.forcePlainText, // deprecated
-                cleanPastedHtml: this.options.cleanPastedHTML, // deprecated
+                cleanPastedHtml: this.options.cleanPastedHtml, // deprecated
                 disableReturn: this.options.disableReturn,
                 targetBlank: this.options.targetBlank,
                 contentWindow: this.options.contentWindow,
@@ -3504,7 +3504,7 @@ function MediumEditor(elements, options) {
         // warn about using deprecated properties
         if (options) {
             [['forcePlainText', 'paste.forcePlainText'],
-             ['cleanPastedHTML', 'paste.cleanPastedHtml']].forEach(function (pair) {
+             ['cleanPastedHtml', 'paste.cleanPastedHtml']].forEach(function (pair) {
                 if (options.hasOwnProperty(pair[0]) && options[pair[0]] !== undefined) {
                     Util.deprecated(pair[0], pair[1]);
                 }

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -127,7 +127,7 @@ describe('Initialization TestCase', function () {
                 lastButtonClass: 'medium-editor-button-last',
                 paste: {
                     forcePlainText: true,
-                    cleanPastedHtml: false,
+                    cleanPastedHTML: false,
                     cleanAttrs: ['class', 'style', 'dir'],
                     cleanTags: ['meta']
                 }

--- a/spec/paste.spec.js
+++ b/spec/paste.spec.js
@@ -90,14 +90,16 @@ describe('Pasting content', function () {
         jasmine.clock().uninstall();
     });
 
-    describe('using cleanPastedHtml option', function () {
+    describe('using cleanPastedHTML option', function () {
         it('should filter multi-line rich-text pastes', function () {
             var i,
                 editorEl = this.el,
                 editor = new MediumEditor('.editor', {
                     delay: 200,
-                    forcePlainText: false,
-                    cleanPastedHtml: true
+                    paste: {
+                        forcePlainText: false,
+                        cleanPastedHTML: true
+                    }
                 });
 
             for (i = 0; i < multiLineTests.length; i += 1) {
@@ -115,8 +117,10 @@ describe('Pasting content', function () {
 
         it('should filter multi-line rich-text pastes when "insertHTML" command is not supported', function () {
             var editor = new MediumEditor('.editor', {
-                forcePlainText: false,
-                cleanPastedHTML: true
+                paste: {
+                    forcePlainText: false,
+                    cleanPastedHTML: true
+                }
             });
 
             spyOn(document, "queryCommandSupported").and.returnValue(false);
@@ -133,13 +137,41 @@ describe('Pasting content', function () {
     });
 
     describe('cleanPaste', function () {
+        it('should filter inline rich-text by passing deprecated options', function () {
+            var i,
+                editorEl = this.el,
+                editor = new MediumEditor('.editor', {
+                    delay: 200,
+                    forcePlainText: false, // deprecated option
+                    cleanPastedHTML: true // deprecated option
+                });
+
+            for (i = 0; i < inlineTests.length; i += 1) {
+
+                // move caret to editor
+                editorEl.innerHTML = 'Before&nbsp;<span id="editor-inner">&nbsp;</span>&nbsp;after.';
+
+                selectElementContents(document.getElementById('editor-inner'));
+
+                editor.cleanPaste(inlineTests[i].paste);
+                jasmine.clock().tick(100);
+
+                // Firefox and IE: doing an insertHTML while this <span> is selected results in the html being inserted inside of the span
+                // Firefox replace the &nbsp; other either side of the <span> with a space
+                // Webkit: doing an insertHTML while this <span> is selected results in the span being replaced completely
+                expect(editorEl.innerHTML).toMatch(new RegExp("^Before(&nbsp;|\\s)(<span id=\"editor-inner\">)?" + inlineTests[i].output + "(</span>)?(&nbsp;|\\s)after\\.$"));
+            }
+        });
+
         it('should filter inline rich-text', function () {
             var i,
                 editorEl = this.el,
                 editor = new MediumEditor('.editor', {
                     delay: 200,
-                    forcePlainText: false,
-                    cleanPastedHtml: true
+                    paste: {
+                        forcePlainText: false,
+                        cleanPastedHTML: true
+                    }
                 });
 
             for (i = 0; i < inlineTests.length; i += 1) {
@@ -161,8 +193,10 @@ describe('Pasting content', function () {
 
         it('should filter inline rich-text when "insertHTML" command is not supported', function () {
             var editor = new MediumEditor('.editor', {
-                    forcePlainText: false,
-                    cleanPastedHtml: true
+                    paste: {
+                        forcePlainText: false,
+                        cleanPastedHTML: true
+                    }
                 });
 
             spyOn(document, "queryCommandSupported").and.returnValue(false);
@@ -185,7 +219,7 @@ describe('Pasting content', function () {
             var editor = new MediumEditor('.editor', {
                 paste: {
                     forcePlainText: false,
-                    cleanPastedHtml: true,
+                    cleanPastedHTML: true,
                     cleanReplacements: [[new RegExp(/<label>/gi), '<sub>'], [new RegExp(/<\/label>/gi), '</sub>']]
                 }
             });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -362,7 +362,7 @@ function MediumEditor(elements, options) {
             // Backwards compatability
             {
                 forcePlainText: this.options.forcePlainText, // deprecated
-                cleanPastedHtml: this.options.cleanPastedHTML, // deprecated
+                cleanPastedHtml: this.options.cleanPastedHtml, // deprecated
                 disableReturn: this.options.disableReturn,
                 targetBlank: this.options.targetBlank,
                 contentWindow: this.options.contentWindow,
@@ -408,7 +408,7 @@ function MediumEditor(elements, options) {
         // warn about using deprecated properties
         if (options) {
             [['forcePlainText', 'paste.forcePlainText'],
-             ['cleanPastedHTML', 'paste.cleanPastedHtml']].forEach(function (pair) {
+             ['cleanPastedHtml', 'paste.cleanPastedHtml']].forEach(function (pair) {
                 if (options.hasOwnProperty(pair[0]) && options[pair[0]] !== undefined) {
                     Util.deprecated(pair[0], pair[1]);
                 }

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -362,7 +362,7 @@ function MediumEditor(elements, options) {
             // Backwards compatability
             {
                 forcePlainText: this.options.forcePlainText, // deprecated
-                cleanPastedHtml: this.options.cleanPastedHtml, // deprecated
+                cleanPastedHtml: this.options.cleanPastedHTML, // deprecated
                 disableReturn: this.options.disableReturn,
                 targetBlank: this.options.targetBlank,
                 contentWindow: this.options.contentWindow,
@@ -408,7 +408,7 @@ function MediumEditor(elements, options) {
         // warn about using deprecated properties
         if (options) {
             [['forcePlainText', 'paste.forcePlainText'],
-             ['cleanPastedHtml', 'paste.cleanPastedHtml']].forEach(function (pair) {
+             ['cleanPastedHTML', 'paste.cleanPastedHtml']].forEach(function (pair) {
                 if (options.hasOwnProperty(pair[0]) && options[pair[0]] !== undefined) {
                     Util.deprecated(pair[0], pair[1]);
                 }

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -362,7 +362,7 @@ function MediumEditor(elements, options) {
             // Backwards compatability
             {
                 forcePlainText: this.options.forcePlainText, // deprecated
-                cleanPastedHtml: this.options.cleanPastedHtml, // deprecated
+                cleanPastedHTML: this.options.cleanPastedHTML, // deprecated
                 disableReturn: this.options.disableReturn,
                 targetBlank: this.options.targetBlank,
                 contentWindow: this.options.contentWindow,
@@ -408,7 +408,7 @@ function MediumEditor(elements, options) {
         // warn about using deprecated properties
         if (options) {
             [['forcePlainText', 'paste.forcePlainText'],
-             ['cleanPastedHtml', 'paste.cleanPastedHtml']].forEach(function (pair) {
+             ['cleanPastedHTML', 'paste.cleanPastedHTML']].forEach(function (pair) {
                 if (options.hasOwnProperty(pair[0]) && options[pair[0]] !== undefined) {
                     Util.deprecated(pair[0], pair[1]);
                 }

--- a/src/js/defaults/options.js
+++ b/src/js/defaults/options.js
@@ -41,7 +41,7 @@ var editorDefaults;
 
         paste: {
             forcePlainText: true,
-            cleanPastedHtml: false,
+            cleanPastedHTML: false,
             cleanAttrs: ['class', 'style', 'dir'],
             cleanTags: ['meta']
         }

--- a/src/js/paste.js
+++ b/src/js/paste.js
@@ -68,7 +68,7 @@ var PasteHandler;
         this.base = instance;
         this.options = options;
 
-        if (this.options.forcePlainText || this.options.cleanPastedHtml) {
+        if (this.options.forcePlainText || this.options.cleanPastedHTML) {
             this.base.subscribe('editablePaste', this.handlePaste.bind(this));
         }
     };
@@ -97,7 +97,7 @@ var PasteHandler;
                     !event.defaultPrevented) {
                 event.preventDefault();
 
-                if (this.options.cleanPastedHtml && event.clipboardData.getData(dataFormatHTML)) {
+                if (this.options.cleanPastedHTML && event.clipboardData.getData(dataFormatHTML)) {
                     return this.cleanPaste(event.clipboardData.getData(dataFormatHTML));
                 }
 

--- a/src/js/paste.js
+++ b/src/js/paste.js
@@ -50,9 +50,9 @@ var PasteHandler;
     /* Paste Options:
      *
      * forcePlainText: Forces pasting as plain text. Default: true
-     * cleanPastedHtml: cleans pasted content from different sources, like google docs etc. Default: false
+     * cleanPastedHTML: cleans pasted content from different sources, like google docs etc. Default: false
      * cleanReplacements: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when
-     *                    __forcePlainText__ or __cleanPastedHtml__ are `true` OR when calling `cleanPaste(text)`
+     *                    __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)`
      *                    helper method. Default: []
      * cleanAttrs: list of attributes to remove when ... default: ['class', 'style', 'dir']
      * cleanTags: list of element tag names to remove... default: ['meta']

--- a/src/js/paste.js
+++ b/src/js/paste.js
@@ -68,7 +68,7 @@ var PasteHandler;
         this.base = instance;
         this.options = options;
 
-        if (this.options.forcePlainText || this.options.cleanPastedHTML) {
+        if (this.options.forcePlainText || this.options.cleanPastedHtml) {
             this.base.subscribe('editablePaste', this.handlePaste.bind(this));
         }
     };
@@ -97,7 +97,7 @@ var PasteHandler;
                     !event.defaultPrevented) {
                 event.preventDefault();
 
-                if (this.options.cleanPastedHTML && event.clipboardData.getData(dataFormatHTML)) {
+                if (this.options.cleanPastedHtml && event.clipboardData.getData(dataFormatHTML)) {
                     return this.cleanPaste(event.clipboardData.getData(dataFormatHTML));
                 }
 


### PR DESCRIPTION
I noticed after migrating from v3.0.9 to v4.x the option name `cleanPastedHTML` has been deprecated and should be used `paste.cleanPastedHtml` instead. it turns out that this deprecated option is not displaying warning in the console and also when passing the newly option `paste.cleanPastedHtml` the content does not get cleaned as expected.

This PR addresses to:
- fix missing deprecated warning for passing the option `cleanPastedHTML` used in v3.0.9 and earlier.

- fix `cleanPastedHtml` option. As of v4.0.0 this option is defined in camelCase format when this options is passed along with `paste` option it does not clean up the pasted html.