### PR TITLE
Fix Fontawesome in demo for HTTPS

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css" id="medium-editor-theme">
 </head>


### PR DESCRIPTION
By leaving out the schema, the browser will automatically select between HTTP/HTTPS. This helps with Chrome, who's refusing to load HTTP content, when the main website is served over HTTPS.