### PR TITLE
Speed up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
+# faster builds on new travis setup not using sudo
+sudo: false
+
+# cache vendor dirs
+cache:
+    directories:
+        - node_modules
+
 language: node_js
+
 notifications:
     email: false
     webhooks:
@@ -7,12 +16,16 @@ notifications:
         on_success: change  # options: [always|never|change] default: always
         on_failure: always  # options: [always|never|change] default: always
         on_start: false     # default: false
+
 before_script:
     - npm install -g grunt-cli
+
 script:
     - npm run test:ci
+
 addons:
     sauce_connect: true
+
 env:
     global:
         - secure: uSn+psGGU4v96aLw3egOywFLaZ1nAjwzbwpn/yUWXanPllHi7LZIe4tY41GfrE4CmD+brAQFRPkuxUnk5uOdtnwLPo5eSg/NAWEIVws2/UnPisr63YopB/LTLP9NqcUklZ8IsE3gcXrhMZWJBm5wfXj9pO+182zp6XHzID1yDAE=


### PR DESCRIPTION
Regarding my previous PR, I've seen you didn't use the container based infra of Travis.

This infra speed up test by starting them faster than the non-container one.
If you check http://www.traviscistatus.com/ you'll see that the non-container can form a bottleneck (usually when both US and EU are awake) while the container infra is never full.

:arrow_right: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Also, when switching to container based infra, we can cache deps and they can be shared between builds.

:arrow_right: http://docs.travis-ci.com/user/caching/