### PR TITLE
Fix line breaks on Safari

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -1,7 +1,7 @@
 /*global describe, it, expect, spyOn,
     fireEvent, prepareEvent, firePreparedEvent, afterEach, beforeEach,
     selectElementContents, setupTestHelpers, placeCursorInsideElement,
-    isFirefox, isIE, Util, selectElementContentsAndFire */
+    isFirefox, isIE, isSafari, Util, selectElementContentsAndFire */
 
 describe('Content TestCase', function () {
     'use strict';

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -195,7 +195,7 @@ describe('Content TestCase', function () {
 
             var editor = this.newMediumEditor('.editor'),
                 p = editor.elements[0].querySelector('p'),
-                isSafari = isSafari();
+                s = isSafari();
 
             spyOn(document, 'execCommand').and.callThrough();
 
@@ -203,8 +203,8 @@ describe('Content TestCase', function () {
 
             fireEvent(p, 'keyup', {
                 keyCode: Util.keyCode.ENTER,
-                ctrlKey: isSafari,
-                shiftKey: !isSafari
+                ctrlKey: s,
+                shiftKey: !s
             });
 
             expect(document.execCommand).not.toHaveBeenCalledWith('formatBlock', false, 'p');

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -189,7 +189,7 @@ describe('Content TestCase', function () {
             expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, 'p');
             expect(this.el.innerHTML).toBe('<p>lorem ipsum</p>');
         });
-        
+
         it('with ctrl key (Safari) or with shift key (other browsers), should insert a line break', function () {
             this.el.innerHTML = '<p>lorem ipsum</p>';
 

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -194,7 +194,8 @@ describe('Content TestCase', function () {
             this.el.innerHTML = '<p>lorem ipsum</p>';
 
             var editor = this.newMediumEditor('.editor'),
-                p = editor.elements[0].querySelector('p');
+                p = editor.elements[0].querySelector('p'),
+                isSafari = isSafari();
 
             spyOn(document, 'execCommand').and.callThrough();
 
@@ -202,8 +203,8 @@ describe('Content TestCase', function () {
 
             fireEvent(p, 'keyup', {
                 keyCode: Util.keyCode.ENTER,
-                ctrlKey: (isSafari() ? true : false),
-                shiftKey: (!isSafari() ? true : false)
+                ctrlKey: isSafari,
+                shiftKey: !isSafari
             });
 
             expect(document.execCommand).not.toHaveBeenCalledWith('formatBlock', false, 'p');

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -1,7 +1,7 @@
 /*global describe, it, expect, spyOn,
     fireEvent, prepareEvent, firePreparedEvent, afterEach, beforeEach,
     selectElementContents, setupTestHelpers, placeCursorInsideElement,
-    isFirefox, isIE, isSafari, Util, selectElementContentsAndFire */
+    isFirefox, isIE, Util, selectElementContentsAndFire */
 
 describe('Content TestCase', function () {
     'use strict';
@@ -190,12 +190,11 @@ describe('Content TestCase', function () {
             expect(this.el.innerHTML).toBe('<p>lorem ipsum</p>');
         });
 
-        it('with ctrl key (Safari) or with shift key (other browsers), should insert a line break', function () {
+        it('with ctrl key, should not call formatBlock', function () {
             this.el.innerHTML = '<p>lorem ipsum</p>';
 
             var editor = this.newMediumEditor('.editor'),
-                p = editor.elements[0].querySelector('p'),
-                s = isSafari();
+                p = editor.elements[0].querySelector('p');
 
             spyOn(document, 'execCommand').and.callThrough();
 
@@ -203,12 +202,10 @@ describe('Content TestCase', function () {
 
             fireEvent(p, 'keyup', {
                 keyCode: Util.keyCode.ENTER,
-                ctrlKey: s,
-                shiftKey: !s
+                ctrlKey: true
             });
 
             expect(document.execCommand).not.toHaveBeenCalledWith('formatBlock', false, 'p');
-            expect(this.el.innerHTML).toBe('<p><br>lorem ipsum</p>');
         });
     });
 

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -189,6 +189,26 @@ describe('Content TestCase', function () {
             expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, 'p');
             expect(this.el.innerHTML).toBe('<p>lorem ipsum</p>');
         });
+        
+        it('with ctrl key (Safari) or with shift key (other browsers), should insert a line break', function () {
+            this.el.innerHTML = '<p>lorem ipsum</p>';
+
+            var editor = this.newMediumEditor('.editor'),
+                p = editor.elements[0].querySelector('p');
+
+            spyOn(document, 'execCommand').and.callThrough();
+
+            placeCursorInsideElement(p, 0);
+
+            fireEvent(p, 'keyup', {
+                keyCode: Util.keyCode.ENTER,
+                ctrlKey: (isSafari() ? true : false),
+                shiftKey: (!isSafari() ? true : false)
+            });
+
+            expect(document.execCommand).not.toHaveBeenCalledWith('formatBlock', false, 'p');
+            expect(this.el.innerHTML).toBe('<p><br>lorem ipsum</p>');
+        });
     });
 
     describe('should unlink anchors', function () {

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -64,6 +64,10 @@ function isFirefox() {
     return navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
 }
 
+function isSafari() {
+    return navigator.userAgent.toLowerCase().indexOf('safari') !== -1;
+}
+
 function dataURItoBlob(dataURI) {
     // convert base64/URLEncoded data component to raw binary data held in a string
     var byteString,

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -64,10 +64,6 @@ function isFirefox() {
     return navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
 }
 
-function isSafari() {
-    return navigator.userAgent.toLowerCase().indexOf('safari') !== -1;
-}
-
 function dataURItoBlob(dataURI) {
     // convert base64/URLEncoded data component to raw binary data held in a string
     var byteString,

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -150,7 +150,7 @@ function MediumEditor(elements, options) {
             // For anchor tags, unlink
             if (tagName === 'a') {
                 this.options.ownerDocument.execCommand('unlink', false, null);
-            } else if (!event.shiftKey) {
+            } else if (!event.shiftKey && !event.ctrlKey) {
                 // only format block if this is not a header tag
                 if (!/h\d/.test(tagName)) {
                     this.options.ownerDocument.execCommand('formatBlock', false, 'p');


### PR DESCRIPTION
On recent Safari browsers, it's impossible to insert a line break as Shift + Enter just makes a new paragraph.

Ctrl + Enter works better, creating the `<br>`, but it also creates a new paragraph and results in a paragraph inside another.

In addition to checking !event.shiftKey in handleKeyup(), the code should check for !event.ctrlKey so that execCommand('formatBlock', false, 'p') won't be called.