### PR TITLE
Toolbar events

### DIFF
--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -106,7 +106,34 @@ describe('Toolbar TestCase', function () {
             expect(callback).toHaveBeenCalled();
         });
 
-        // @deprecated
+        it('should be possible to listen to toolbar events from extensions', function () {
+            var TestExtension = function () {},
+                callbackShow = jasmine.createSpy('show'),
+                callbackHide = jasmine.createSpy('hide');
+
+            TestExtension.prototype.parent = true;
+            TestExtension.prototype.init = function () {
+                this.base.subscribe('showToolbar', callbackShow);
+                this.base.subscribe('hideToolbar', callbackHide);
+            };
+
+            var editor = this.newMediumEditor('.editor', {
+                extensions: { 'testExtension': new TestExtension() }
+            });
+
+            this.el.innerHTML = 'specOnShowToolbarTest';
+
+            selectElementContentsAndFire(this.el, { eventToFire: 'focus' });
+            expect(callbackShow).toHaveBeenCalled();
+
+            // Remove selection and call check selection, which should make the toolbar be hidden
+            jasmine.clock().tick(1);
+            window.getSelection().removeAllRanges();
+            editor.checkSelection();
+
+            expect(callbackHide).toHaveBeenCalled();
+        });
+
         it('should call onShowToolbar when toolbar is shown and onHideToolbar when toolbar is hidden', function () {
             var editor,
                 temp = {

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -85,7 +85,7 @@ describe('Toolbar TestCase', function () {
 
             selectElementContentsAndFire(this.el, { eventToFire: 'focus' });
 
-            expect(callback).toHaveBeenCalled();
+            expect(callback).toHaveBeenCalledWith({}, this.el);
         });
 
         it('should trigger the hideToolbar custom event when toolbar is hidden', function () {
@@ -103,7 +103,7 @@ describe('Toolbar TestCase', function () {
             window.getSelection().removeAllRanges();
             editor.checkSelection();
 
-            expect(callback).toHaveBeenCalled();
+            expect(callback).toHaveBeenCalledWith({}, this.el);
         });
 
         it('should be possible to listen to toolbar events from extensions', function () {
@@ -124,14 +124,14 @@ describe('Toolbar TestCase', function () {
             this.el.innerHTML = 'specOnShowToolbarTest';
 
             selectElementContentsAndFire(this.el, { eventToFire: 'focus' });
-            expect(callbackShow).toHaveBeenCalled();
+            expect(callbackShow).toHaveBeenCalledWith({}, this.el);
 
             // Remove selection and call check selection, which should make the toolbar be hidden
             jasmine.clock().tick(1);
             window.getSelection().removeAllRanges();
             editor.checkSelection();
 
-            expect(callbackHide).toHaveBeenCalled();
+            expect(callbackHide).toHaveBeenCalledWith({}, this.el);
         });
 
         it('should call onShowToolbar when toolbar is shown and onHideToolbar when toolbar is hidden', function () {

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -1,7 +1,7 @@
 /*global MediumEditor, describe, it, expect, spyOn,
     afterEach, beforeEach, selectElementContents,
     fireEvent, setupTestHelpers, jasmine, selectElementContentsAndFire,
-    placeCursorInsideElement, Toolbar */
+    placeCursorInsideElement, Toolbar*/
 
 describe('Toolbar TestCase', function () {
     'use strict';
@@ -75,7 +75,39 @@ describe('Toolbar TestCase', function () {
             expect(editor.toolbar.getToolbarElement().querySelector('button[data-action="bold"]').classList.contains('medium-editor-button-active')).toBe(true);
         });
 
-        it('should call onShowToolbar when toolbar is shwon and onHideToolbar when toolbar is hidden', function () {
+        it('should trigger the showToolbar custom event when toolbar is shown', function () {
+            var editor = this.newMediumEditor('.editor'),
+                callback = jasmine.createSpy();
+
+            this.el.innerHTML = 'specOnShowToolbarTest';
+
+            editor.subscribe('showToolbar', callback);
+
+            selectElementContentsAndFire(this.el, { eventToFire: 'focus' });
+
+            expect(callback).toHaveBeenCalled();
+        });
+
+        it('should trigger the hideToolbar custom event when toolbar is hidden', function () {
+            var editor = this.newMediumEditor('.editor'),
+                callback = jasmine.createSpy();
+
+            this.el.innerHTML = 'specOnShowToolbarTest';
+
+            editor.subscribe('hideToolbar', callback);
+
+            selectElementContentsAndFire(this.el, { eventToFire: 'focus' });
+
+            // Remove selection and call check selection, which should make the toolbar be hidden
+            jasmine.clock().tick(1);
+            window.getSelection().removeAllRanges();
+            editor.checkSelection();
+
+            expect(callback).toHaveBeenCalled();
+        });
+
+        // @deprecated
+        it('should call onShowToolbar when toolbar is shown and onHideToolbar when toolbar is hidden', function () {
             var editor,
                 temp = {
                     onShow: function () {},

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -436,8 +436,9 @@ function MediumEditor(elements, options) {
         // add toolbar custom events to the list of known events by the editor
         // we need to have this for the initialization of extensions
         // initToolbar is called after initCommands
-        this.events.defineCustomEvent('showToolbar');
-        this.events.defineCustomEvent('hideToolbar');
+        // add toolbar custom events to the list of known events by the editor
+        this.createEvent('showToolbar');
+        this.createEvent('hideToolbar');
 
         buttons.forEach(function (buttonName) {
             if (extensions[buttonName]) {
@@ -655,6 +656,14 @@ function MediumEditor(elements, options) {
 
         unsubscribe: function (event, listener) {
             this.events.detachCustomEvent(event, listener);
+        },
+
+        createEvent: function (event) {
+            this.events.defineCustomEvent(event);
+        },
+
+        trigger: function (name, data, editable) {
+            this.events.triggerCustomEvent(name, data, editable);
         },
 
         delay: function (fn) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1,7 +1,7 @@
 /*global Util, ButtonsData, Button,
  Selection, FontSizeForm, Extension, extensionDefaults,
  Toolbar, AutoLink, ImageDragging, Events, editorDefaults,
- DefaultButton, AnchorExtension, FontSizeExtension, AnchorPreviewDeprecated */
+ DefaultButton, AnchorExtension, FontSizeExtension, AnchorPreviewDeprecated*/
 
 function MediumEditor(elements, options) {
     'use strict';
@@ -432,6 +432,12 @@ function MediumEditor(elements, options) {
             ext,
             name;
         this.commands = [];
+
+        // add toolbar custom events to the list of known events by the editor
+        // we need to have this for the initialization of extensions
+        // initToolbar is called after initCommands
+        this.events.defineCustomEvent('showToolbar');
+        this.events.defineCustomEvent('hideToolbar');
 
         buttons.forEach(function (buttonName) {
             if (extensions[buttonName]) {

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -1,4 +1,4 @@
-/*global Util */
+/*global Util*/
 
 var Events;
 
@@ -70,6 +70,10 @@ var Events;
                 this.customEvents[event].splice(index, 1);
                 // TODO: If array is empty, should detach internal listeners via destoryListener()
             }
+        },
+
+        defineCustomEvent: function (event) {
+            this.listeners[event] = true;
         },
 
         indexOfCustomListener: function (event, listener) {

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -177,13 +177,6 @@ var Extension;
          * or the combination of queryCommandState(), isAlreadyApplied(node),
          * isActive(), and setActive()
          */
-        setInactive: null,
-
-        /* onHide: [function ()]
-         *
-         * If implemented, this function is called each time the
-         * toolbar is hidden
-         */
-        onHide: null
+        setInactive: null
     };
 })();

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -8,6 +8,7 @@ var Toolbar;
     Toolbar = function Toolbar(instance) {
         this.base = instance;
         this.options = instance.options;
+
         this.initThrottledMethods();
     };
 
@@ -192,7 +193,7 @@ var Toolbar;
             clearTimeout(this.hideTimeout);
             if (!this.isDisplayed()) {
                 this.getToolbarElement().classList.add('medium-editor-toolbar-active');
-                this.base.events.triggerCustomEvent('showToolbar', {}, this.base.getFocusedElement());
+                this.base.trigger('showToolbar', {}, this.base.getFocusedElement());
 
                 if (typeof this.options.onShowToolbar === 'function') {
                     this.options.onShowToolbar();
@@ -203,7 +204,7 @@ var Toolbar;
         hideToolbar: function () {
             if (this.isDisplayed()) {
                 this.getToolbarElement().classList.remove('medium-editor-toolbar-active');
-                this.base.events.triggerCustomEvent('hideToolbar', {}, this.base.getFocusedElement());
+                this.base.trigger('hideToolbar', {}, this.base.getFocusedElement());
 
                 this.base.commands.forEach(function (extension) {
                     if (typeof extension.onHide === 'function') {

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -113,9 +113,6 @@ var Toolbar;
 
         attachEventHandlers: function () {
 
-            this.base.events.defineCustomEvent('showToolbar');
-            this.base.events.defineCustomEvent('hideToolbar');
-
             // MediumEditor custom events for when user beings and ends interaction with a contenteditable and its elements
             this.base.subscribe('blur', this.handleBlur.bind(this));
             this.base.subscribe('focus', this.handleFocus.bind(this));
@@ -198,7 +195,6 @@ var Toolbar;
                 this.base.events.triggerCustomEvent('showToolbar', {}, {});
 
                 if (typeof this.options.onShowToolbar === 'function') {
-                    Util.deprecated('onShowToolbar', 'the showToolbar event instead');
                     this.options.onShowToolbar();
                 }
             }
@@ -217,7 +213,6 @@ var Toolbar;
                 });
 
                 if (typeof this.options.onHideToolbar === 'function') {
-                    Util.deprecated('onHideToolbar', 'the hideToolbar event instead');
                     this.options.onHideToolbar();
                 }
             }

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -207,7 +207,7 @@ var Toolbar;
 
                 this.base.commands.forEach(function (extension) {
                     if (typeof extension.onHide === 'function') {
-                        Util.deprecated('onHideToolbar', 'the hideToolbar event instead');
+                        Util.deprecated('onHide', 'the hideToolbar event instead');
                         extension.onHide();
                     }
                 });

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -1,4 +1,4 @@
-/*global Util, Selection */
+/*global Util, Selection*/
 
 var Toolbar;
 
@@ -113,6 +113,9 @@ var Toolbar;
 
         attachEventHandlers: function () {
 
+            this.base.events.defineCustomEvent('showToolbar');
+            this.base.events.defineCustomEvent('hideToolbar');
+
             // MediumEditor custom events for when user beings and ends interaction with a contenteditable and its elements
             this.base.subscribe('blur', this.handleBlur.bind(this));
             this.base.subscribe('focus', this.handleFocus.bind(this));
@@ -192,7 +195,10 @@ var Toolbar;
             clearTimeout(this.hideTimeout);
             if (!this.isDisplayed()) {
                 this.getToolbarElement().classList.add('medium-editor-toolbar-active');
+                this.base.events.triggerCustomEvent('showToolbar', {}, {});
+
                 if (typeof this.options.onShowToolbar === 'function') {
+                    Util.deprecated('onShowToolbar', 'the showToolbar event instead');
                     this.options.onShowToolbar();
                 }
             }
@@ -200,14 +206,18 @@ var Toolbar;
 
         hideToolbar: function () {
             if (this.isDisplayed()) {
+                this.getToolbarElement().classList.remove('medium-editor-toolbar-active');
+                this.base.events.triggerCustomEvent('hideToolbar', {}, {});
+
                 this.base.commands.forEach(function (extension) {
                     if (typeof extension.onHide === 'function') {
+                        Util.deprecated('onHideToolbar', 'the hideToolbar event instead');
                         extension.onHide();
                     }
                 });
 
-                this.getToolbarElement().classList.remove('medium-editor-toolbar-active');
                 if (typeof this.options.onHideToolbar === 'function') {
+                    Util.deprecated('onHideToolbar', 'the hideToolbar event instead');
                     this.options.onHideToolbar();
                 }
             }

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -344,6 +344,11 @@ var Toolbar;
             }
         },
 
+        // leaving here backward compatibility / statics
+        getFocusedElement: function () {
+            return this.base.getFocusedElement();
+        },
+
         // Updating the toolbar
 
         showAndUpdateToolbar: function () {

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -192,7 +192,7 @@ var Toolbar;
             clearTimeout(this.hideTimeout);
             if (!this.isDisplayed()) {
                 this.getToolbarElement().classList.add('medium-editor-toolbar-active');
-                this.base.events.triggerCustomEvent('showToolbar', {}, {});
+                this.base.events.triggerCustomEvent('showToolbar', {}, this.getFocusedElement());
 
                 if (typeof this.options.onShowToolbar === 'function') {
                     this.options.onShowToolbar();
@@ -203,7 +203,7 @@ var Toolbar;
         hideToolbar: function () {
             if (this.isDisplayed()) {
                 this.getToolbarElement().classList.remove('medium-editor-toolbar-active');
-                this.base.events.triggerCustomEvent('hideToolbar', {}, {});
+                this.base.events.triggerCustomEvent('hideToolbar', {}, this.getFocusedElement());
 
                 this.base.commands.forEach(function (extension) {
                     if (typeof extension.onHide === 'function') {

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -192,7 +192,7 @@ var Toolbar;
             clearTimeout(this.hideTimeout);
             if (!this.isDisplayed()) {
                 this.getToolbarElement().classList.add('medium-editor-toolbar-active');
-                this.base.events.triggerCustomEvent('showToolbar', {}, this.getFocusedElement());
+                this.base.events.triggerCustomEvent('showToolbar', {}, this.base.getFocusedElement());
 
                 if (typeof this.options.onShowToolbar === 'function') {
                     this.options.onShowToolbar();
@@ -203,7 +203,7 @@ var Toolbar;
         hideToolbar: function () {
             if (this.isDisplayed()) {
                 this.getToolbarElement().classList.remove('medium-editor-toolbar-active');
-                this.base.events.triggerCustomEvent('hideToolbar', {}, this.getFocusedElement());
+                this.base.events.triggerCustomEvent('hideToolbar', {}, this.base.getFocusedElement());
 
                 this.base.commands.forEach(function (extension) {
                     if (typeof extension.onHide === 'function') {
@@ -308,7 +308,7 @@ var Toolbar;
 
                 // If no editable has focus OR selection is inside contenteditable = false
                 // hide toolbar
-                if (!this.getFocusedElement() ||
+                if (!this.base.getFocusedElement() ||
                         Selection.selectionInContentEditableFalse(this.options.contentWindow)) {
                     this.hideToolbar();
                     return;
@@ -341,15 +341,6 @@ var Toolbar;
                     this.showAndUpdateToolbar();
                 }
             }
-        },
-
-        getFocusedElement: function () {
-            for (var i = 0; i < this.base.elements.length; i += 1) {
-                if (this.base.elements[i].getAttribute('data-medium-focused')) {
-                    return this.base.elements[i];
-                }
-            }
-            return null;
         },
 
         // Updating the toolbar
@@ -433,7 +424,7 @@ var Toolbar;
         },
 
         setToolbarPosition: function () {
-            var container = this.getFocusedElement(),
+            var container = this.base.getFocusedElement(),
                 selection = this.options.contentWindow.getSelection(),
                 anchorPreview;
 


### PR DESCRIPTION
Add custom eventos for showing and hiding the toolbar so extensions can listen to it if they want instead of using a predefined method.