### PR TITLE
Deprecate .parent property of extensions

### DIFF
--- a/demo/pass-instance.html
+++ b/demo/pass-instance.html
@@ -24,8 +24,6 @@
     <script src="../dist/js/medium-editor.js"></script>
     <script>
         function Extension() {
-          this.parent = true;
-
           this.button = document.createElement('button');
           this.button.className = 'medium-editor-action';
           this.button.innerText = 'X';

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -105,7 +105,6 @@ describe('Extensions TestCase', function () {
             var Sub, editor, e1, e2;
 
             Sub = Extension.extend({
-                parent: true,
                 y: 10
             });
 
@@ -215,49 +214,64 @@ describe('Extensions TestCase', function () {
     });
 
     describe('Set data in extensions', function () {
-        var ExtensionOne = function () {
-                this.parent = true;
-            },
-            ExtensionTwo = function () {},
-            extOne = new ExtensionOne(),
-            extTwo = new ExtensionTwo();
-
-        it('should check if extension class has parent attribute', function () {
-            var editor = this.newMediumEditor('.editor', {
-                extensions: {
-                    'one': extOne,
-                    'two': extTwo
-                }
-            });
-
-            expect(editor instanceof MediumEditor).toBeTruthy();
-            expect(extOne.parent).toBeTruthy();
-            expect(extTwo.parent).toBeUndefined();
-        });
-
-        it('should set the base attribute to be an instance of editor', function () {
-            var editor = this.newMediumEditor('.editor', {
-                extensions: {
-                    'one': extOne,
-                    'two': extTwo
-                }
-            });
+        it('should set the base property to an instance of MediumEditor', function () {
+            var extOne = new MediumEditor.Extension(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'one': extOne
+                    }
+                });
 
             expect(editor instanceof MediumEditor).toBeTruthy();
             expect(extOne.base instanceof MediumEditor).toBeTruthy();
-            expect(extTwo.base).toBeUndefined();
         });
 
-        it('should set the name of the extension', function () {
-            this.newMediumEditor('.editor', {
-                extensions: {
-                    'one': extOne,
-                    'two': extTwo
-                }
-            });
+        it('should not set the base property when deprecated parent attribute is set to false', function () {
+            var TempExtension = MediumEditor.Extension.extend({
+                    parent: false
+                }),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'temp': new TempExtension()
+                    }
+                });
+
+            expect(editor instanceof MediumEditor).toBeTruthy();
+            expect(editor.getExtensionByName('temp').base).toBeUndefined();
+        });
+
+        it('should not override the base or name properties of an extension if overriden', function () {
+            var TempExtension = MediumEditor.Extension.extend({
+                    name: 'tempExtension',
+                    base: 'something'
+                }),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'one': new TempExtension()
+                    }
+                });
+
+            expect(editor.getExtensionByName('one')).toBeUndefined();
+            expect(editor.getExtensionByName('tempExtension').base).toBe('something');
+        });
+
+        it('should set the name of property of extensions', function () {
+            var ExtensionOne = function () {},
+                ExtensionTwo = function () {},
+                extOne = new ExtensionOne(),
+                extTwo = new ExtensionTwo(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'one': extOne,
+                        'two': extTwo
+                    }
+                });
 
             expect(extOne.name).toBe('one');
             expect(extTwo.name).toBe('two');
+
+            expect(editor.getExtensionByName('one')).toBe(extOne);
+            expect(editor.getExtensionByName('two')).toBe(extTwo);
         });
     });
 });

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -111,7 +111,6 @@ describe('Toolbar TestCase', function () {
                 callbackShow = jasmine.createSpy('show'),
                 callbackHide = jasmine.createSpy('hide');
 
-            TestExtension.prototype.parent = true;
             TestExtension.prototype.init = function () {
                 this.base.subscribe('showToolbar', callbackShow);
                 this.base.subscribe('hideToolbar', callbackHide);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -187,10 +187,17 @@ function MediumEditor(elements, options) {
     }
 
     function initExtension(extension, name, instance) {
-        if (extension.parent) {
+        if (typeof extension.parent !== 'undefined') {
+            Util.warn('Extension .parent property has been deprecated.  ' +
+                'The .base property for extensions will always be set to MediumEditor in version 5.0.0');
+        }
+        // TODO: Deprecated (Remove .parent check in v5.0.0)
+        if (extension.parent !== false &&
+            extension.base === undefined) {
             extension.base = instance;
         }
         if (typeof extension.init === 'function') {
+            // Passing instance into init() will be deprecated in v5.0.0
             extension.init(instance);
         }
         if (!extension.name) {

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -1,9 +1,8 @@
-/* global Util */
-
 var Extension;
-
 (function () {
     'use strict';
+
+    /* global Util */
 
     Extension = function (options) {
         Util.extend(this, options);
@@ -70,29 +69,21 @@ var Extension;
     };
 
     Extension.prototype = {
-        init: function (/* instance */) {
-            // called when properly decorated and used.
-            // has a .base value pointing to the editor
-            // owning us. has been given a .name if no
-            // name present
-        },
-
-        /* parent: [boolean]
+        /* init: [function]
          *
-         * Setting this to false will prevent MediumEditor
-         * from setting the .base property.
-         * If left as true, the .base property of the extension
-         * will be assigned a reference to the
-         * MediumEditor instance that is using the extension
+         * Called by MediumEditor during initialization.
+         * The .base property will already have been set to
+         * current instance of MediumEditor when this is called.
+         * All helper methods will exist as well
          */
-        parent: true,
+        init: function () {},
 
         /* base: [MediumEditor instance]
          *
-         * If .parent is set to true, this will be set to the
-         * current MediumEditor instance before init() is called
+         * If not overriden, this will be set to the current instance
+         * of MediumEditor, before the init method is called
          */
-        base: null,
+        base: undefined,
 
         /* name: [string]
          *
@@ -101,7 +92,7 @@ var Extension;
          * used when passing the extension into MediumEditor via the
          * 'extensions' option
          */
-        name: null,
+        name: undefined,
 
         /* checkState: [function (node)]
          *
@@ -114,7 +105,7 @@ var Extension;
          * 3) Get the parent node of the previous node
          * 4) Repeat steps #2 and #3 until we move outside the parent contenteditable
          */
-        checkState: null,
+        checkState: undefined,
 
         /* As alternatives to checkState, these functions provide a more structured
          * path to updating the state of an extension (usually a button) whenever
@@ -132,7 +123,7 @@ var Extension;
          * If this function returns true, and the setActive() function is defined
          * setActive() will be called
          */
-        queryCommandState: null,
+        queryCommandState: undefined,
 
         /* isActive: [function ()]
          *
@@ -142,7 +133,7 @@ var Extension;
          * but only if queryCommandState() or isAlreadyApplied() functions
          * are implemented, and when called, return true.
          */
-        isActive: null,
+        isActive: undefined,
 
         /* isAlreadyApplied: [function (node)]
          *
@@ -155,7 +146,7 @@ var Extension;
          * queryCommandState() is implemented and returns a non-null
          * value when called
          */
-        isAlreadyApplied: null,
+        isAlreadyApplied: undefined,
 
         /* setActive: [function ()]
          *
@@ -165,7 +156,7 @@ var Extension;
          * only if queryCommandState() or isAlreadyApplied(node) return
          * true when called
          */
-        setActive: null,
+        setActive: undefined,
 
         /* setInactive: [function ()]
          *
@@ -177,6 +168,6 @@ var Extension;
          * or the combination of queryCommandState(), isAlreadyApplied(node),
          * isActive(), and setActive()
          */
-        setInactive: null
+        setInactive: undefined
     };
 })();

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -6,7 +6,6 @@ var AnchorPreview;
 
     AnchorPreview = Extension.extend({
         name: 'anchor-preview',
-        parent: true,
 
         // Anchor Preview Options
 

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -14,7 +14,6 @@ LINK_REGEXP_TEXT =
     'use strict';
 
     AutoLink = Extension.extend({
-        parent: true,
 
         init: function () {
             this.disableEventHandling = false;

--- a/src/js/extensions/image-dragging.js
+++ b/src/js/extensions/image-dragging.js
@@ -5,8 +5,6 @@ var ImageDragging;
     'use strict';
 
     ImageDragging = Extension.extend({
-        // Need a reference to MediumEditor (this.base)
-        parent: true,
 
         init: function () {
             this.base.subscribe('editableDrag', this.handleDrag.bind(this));

--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -85,9 +85,6 @@ var PasteHandler;
         targetBlank: false,
         disableReturn: false,
 
-        // Need a reference to MediumEditor (this.base)
-        parent: true,
-
         init: function () {
             if (this.forcePlainText || this.cleanPastedHTML) {
                 this.base.subscribe('editablePaste', this.handlePaste.bind(this));

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -7,7 +7,6 @@ var Placeholder;
 
     Placeholder = Extension.extend({
         name: 'placeholder',
-        parent: true,
 
         /* Placeholder Options */
 


### PR DESCRIPTION
Fix #576 

This PR deprecates the `.parent` property for extensions.  Now, all extensions will have their `.base` property set to the instance of MediumEditor they are initialized as part of (unless they already have `.base` set to something else or they have the deprecated `.parent` property set to `false`, but this will only be supported until v5.0.0)

How `.parent` and `.base` work:

* BEFORE this PR
  * ONLY IF `.parent` property of an Extension is `true`, MediumEditor sets `.base` to be a reference to itself (MediumEditor)
* AFTER this PR (but before v5.0.0)
  * IF `.parent` property of an Extension is explicitly `false` OR if `.base` property of an Extension is already set to something, MediumEditor will NOT set `.base` property to be a reference to itself (MediumEditor)
  * For all other cases, MediumEditor will set the `.base` property of all Extensions to be a reference to itself (MediumEditor)
  * This will NOT be completely backwards compatible in all cases, since some extensions will now have a `.base` property when they didn't before.  However, since we won't override if it already exists, this should be good enough to not break existing extensions.
* AFTER v5.0.0
  * All Extensions will have their `.base` property set to an instance of MediumEditor, unless they override the `.base` property to something else before initializing MediumEditor.