### PR TITLE
Pass document + window properties to each extension

### DIFF
--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -53,7 +53,7 @@ describe('Extensions TestCase', function () {
             expect(ext2.aMethod).toHaveBeenCalledWith('theParam');
         });
 
-        it('should call init (and pass the instance of itself) on extensions if the method exists', function () {
+        it('should call init (and pass the deprecated instance of itself) on extensions if the method exists', function () {
             var ExtensionOne = function () {
                 this.init = function (me) {
                     this.me = me;
@@ -80,6 +80,39 @@ describe('Extensions TestCase', function () {
 
             expect(ext1.me instanceof MediumEditor).toBeTruthy();
             expect(ext2.me instanceof MediumEditor).toBeTruthy();
+        });
+
+        it('should set window and document properties on each extension', function () {
+            var TempExtension = MediumEditor.Extension.extend({}),
+                extInstance = new TempExtension(),
+                fakeDocument = {
+                    body: document.body,
+                    documentElement: document.documentElement,
+                    querySelectorAll: function () {
+                        return document.querySelectorAll.apply(document, arguments);
+                    },
+                    createElement: function () {
+                        return document.createElement.apply(document, arguments);
+                    }
+                },
+                fakeWindow = {
+                    addEventListener: function () {
+                        return window.addEventListener.apply(window, arguments);
+                    },
+                    removeEventListener: function () {
+                        return window.removeEventListener.apply(window, arguments);
+                    }
+                };
+            this.newMediumEditor('.editor', {
+                ownerDocument: fakeDocument,
+                contentWindow: fakeWindow,
+                extensions: {
+                    'temp-extension': extInstance
+                }
+            });
+
+            expect(extInstance.window).toBe(fakeWindow);
+            expect(extInstance.document).toBe(fakeDocument);
         });
     });
 

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -168,6 +168,31 @@ var Extension;
          * or the combination of queryCommandState(), isAlreadyApplied(node),
          * isActive(), and setActive()
          */
-        setInactive: undefined
+        setInactive: undefined,
+
+        /************************ Helpers ************************
+         * The following are helpers that are either set by MediumEditor
+         * during initialization, or are helper methods which either
+         * route calls to the MediumEditor instance or provide common
+         * functionality for all extensions
+         *********************************************************/
+
+        /* window: [Window]
+         *
+         * If not overriden, this will be set to the window object
+         * to be used by MediumEditor and its extensions.  This is
+         * passed via the 'contentWindow' option to MediumEditor
+         * and is the global 'window' object by default
+         */
+        'window': undefined,
+
+        /* document: [Document]
+         *
+         * If not overriden, this will be set to the document object
+         * to be used by MediumEditor and its extensions. This is
+         * passed via the 'ownerDocument' optin to MediumEditor
+         * and is the global 'document' object by default
+         */
+        'document': undefined
     };
 })();

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -20,7 +20,7 @@ LINK_REGEXP_TEXT =
             this.base.subscribe('editableKeypress', this.onKeypress.bind(this));
             this.base.subscribe('editableBlur', this.onBlur.bind(this));
             // MS IE has it's own auto-URL detect feature but ours is better in some ways. Be consistent.
-            this.base.options.ownerDocument.execCommand('AutoUrlDetect', false, false);
+            this.document.execCommand('AutoUrlDetect', false, false);
         },
 
         onBlur: function (blurEvent, editable) {
@@ -129,7 +129,7 @@ LINK_REGEXP_TEXT =
         },
 
         findOrCreateMatchingTextNodes: function (element, match) {
-            var treeWalker = this.base.options.ownerDocument.createTreeWalker(element, NodeFilter.SHOW_TEXT,
+            var treeWalker = this.document.createTreeWalker(element, NodeFilter.SHOW_TEXT,
                     null, false),
                 matchedNodes = [],
                 currentTextIndex = 0,
@@ -179,8 +179,8 @@ LINK_REGEXP_TEXT =
                 return false;
             }
 
-            var anchor = document.createElement('a'),
-                span = document.createElement('span');
+            var anchor = this.document.createElement('a'),
+                span = this.document.createElement('span');
             Util.moveTextRangeIntoElement(textNodes[0], textNodes[textNodes.length - 1], span);
             span.setAttribute('data-auto-link', 'true');
             anchor.setAttribute('href', Util.ensureUrlHasProtocol(href));

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -34,7 +34,7 @@ var Button;
             return (typeof this.tagNames === 'function') ? this.tagNames(this.base.options) : this.tagNames;
         },
         createButton: function () {
-            var button = this.base.options.ownerDocument.createElement('button'),
+            var button = this.document.createElement('button'),
                 content = this.contentDefault,
                 ariaLabel = this.getAria();
             button.classList.add('medium-editor-action');
@@ -112,7 +112,7 @@ var Button;
 
             if (!isMatch && this.style) {
                 styleVals = this.style.value.split('|');
-                computedStyle = this.base.options.contentWindow.getComputedStyle(node, null).getPropertyValue(this.style.prop);
+                computedStyle = this.window.getComputedStyle(node, null).getPropertyValue(this.style.prop);
                 styleVals.forEach(function (val) {
                     if (!this.knownState) {
                         isMatch = (computedStyle.indexOf(val) !== -1);

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -20,7 +20,7 @@ var FontSizeForm;
 
             if (!this.isDisplayed()) {
                 // Get fontsize of current selection (convert to string since IE returns this as number)
-                var fontSize = this.base.options.ownerDocument.queryCommandValue('fontSize') + '';
+                var fontSize = this.document.queryCommandValue('fontSize') + '';
                 this.showForm(fontSize);
             }
 
@@ -86,7 +86,7 @@ var FontSizeForm;
         // form creation and event handling
 
         createForm: function () {
-            var doc = this.base.options.ownerDocument,
+            var doc = this.document,
                 form = doc.createElement('div'),
                 input = doc.createElement('input'),
                 close = doc.createElement('a'),
@@ -139,7 +139,7 @@ var FontSizeForm;
         },
 
         clearFontSize: function () {
-            Selection.getSelectedElements(this.base.options.ownerDocument).forEach(function (el) {
+            Selection.getSelectedElements(this.document).forEach(function (el) {
                 if (el.tagName === 'FONT' && el.hasAttribute('size')) {
                     el.removeAttribute('size');
                 }

--- a/src/js/extensions/image-dragging.js
+++ b/src/js/extensions/image-dragging.js
@@ -40,10 +40,10 @@ var ImageDragging;
                         fileReader.readAsDataURL(file);
 
                         id = 'medium-img-' + (+new Date());
-                        Util.insertHTMLCommand(this.base.options.ownerDocument, '<img class="medium-image-loading" id="' + id + '" />');
+                        Util.insertHTMLCommand(this.document, '<img class="medium-image-loading" id="' + id + '" />');
 
                         fileReader.onload = function () {
-                            var img = this.base.options.ownerDocument.getElementById(id);
+                            var img = this.document.getElementById(id);
                             if (img) {
                                 img.removeAttribute('id');
                                 img.removeAttribute('class');

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -564,7 +564,7 @@ var Util;
             }
 
             var afterLast = lastChild.nextSibling,
-                fragment = document.createDocumentFragment();
+                fragment = rootNode.ownerDocument.createDocumentFragment();
 
             // build up fragment on startNode side of tree
             if (firstChild === startNode) {


### PR DESCRIPTION
This PR covers passing `options.ownerDocument` and `options.contentWindow` into each extension as `.document` and `.window` properties (respectively)