### PR TITLE
Create extension helper methods

### DIFF
--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -247,6 +247,38 @@ describe('Extensions TestCase', function () {
                 expect((editor[helper]).calls.count()).toBe(1);
             });
         });
+
+        it('should be able to access the editor id via getEditorId()', function () {
+            var tempExtension = new MediumEditor.Extension(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'temp-extension': tempExtension
+                    }
+                });
+            expect(tempExtension.getEditorId()).toBe(editor.id);
+        });
+
+        it('should be able to access elements in this editor via getEditorElements()', function () {
+            var tempExtension = new MediumEditor.Extension(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'temp-extension': tempExtension
+                    }
+                });
+            expect(tempExtension.getEditorElements()).toBe(editor.elements);
+        });
+
+        it('should be able to access editor options via getEditorOption()', function () {
+            var tempExtension = new MediumEditor.Extension(),
+                editor = this.newMediumEditor('.editor', {
+                    disableReturn: true,
+                    extensions: {
+                        'temp-extension': tempExtension
+                    }
+                });
+            expect(tempExtension.getEditorOption('disableReturn')).toBe(true);
+            expect(tempExtension.getEditorOption('spellcheck')).toBe(editor.options.spellcheck);
+        });
     });
 
     describe('Button integration', function () {

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -167,7 +167,8 @@ describe('Extensions TestCase', function () {
             var noop = function () {},
                 helpers = {
                     'on': [document, 'click', noop, false],
-                    'off': [document, 'click', noop, false]
+                    'off': [document, 'click', noop, false],
+                    'subscribe': ['editableClick', noop]
                 },
                 tempExtension = new MediumEditor.Extension(),
                 editor = this.newMediumEditor('.editor', {

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -162,6 +162,31 @@ describe('Extensions TestCase', function () {
 
     });
 
+    describe('All extensions', function () {
+        it('should get helper methods to call into base instance methods', function () {
+            var noop = function () {},
+                helpers = {
+                    'on': [document, 'click', noop, false],
+                    'off': [document, 'click', noop, false]
+                },
+                tempExtension = new MediumEditor.Extension(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'temp-extension': tempExtension
+                    }
+                });
+
+            Object.keys(helpers).forEach(function (helper) {
+                spyOn(editor, helper).and.callThrough();
+            });
+
+            Object.keys(helpers).forEach(function (helper) {
+                tempExtension[helper].apply(tempExtension, helpers[helper]);
+                expect((editor[helper]).calls.count()).toBe(1);
+            });
+        });
+    });
+
     describe('Button integration', function () {
 
         var ExtensionWithElement = {

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -228,7 +228,8 @@ describe('Extensions TestCase', function () {
                 helpers = {
                     'on': [document, 'click', noop, false],
                     'off': [document, 'click', noop, false],
-                    'subscribe': ['editableClick', noop]
+                    'subscribe': ['editableClick', noop],
+                    'execAction': ['bold']
                 },
                 tempExtension = new MediumEditor.Extension(),
                 editor = this.newMediumEditor('.editor', {
@@ -238,7 +239,7 @@ describe('Extensions TestCase', function () {
                 });
 
             Object.keys(helpers).forEach(function (helper) {
-                spyOn(editor, helper).and.callThrough();
+                spyOn(editor, helper);
             });
 
             Object.keys(helpers).forEach(function (helper) {

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -82,6 +82,66 @@ describe('Extensions TestCase', function () {
             expect(ext2.me instanceof MediumEditor).toBeTruthy();
         });
 
+        it('should set the base property to an instance of MediumEditor', function () {
+            var extOne = new MediumEditor.Extension(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'one': extOne
+                    }
+                });
+
+            expect(editor instanceof MediumEditor).toBeTruthy();
+            expect(extOne.base instanceof MediumEditor).toBeTruthy();
+        });
+
+        it('should not set the base property when deprecated parent attribute is set to false', function () {
+            var TempExtension = MediumEditor.Extension.extend({
+                    parent: false
+                }),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'temp': new TempExtension()
+                    }
+                });
+
+            expect(editor instanceof MediumEditor).toBeTruthy();
+            expect(editor.getExtensionByName('temp').base).toBeUndefined();
+        });
+
+        it('should not override the base or name properties of an extension if overriden', function () {
+            var TempExtension = MediumEditor.Extension.extend({
+                    name: 'tempExtension',
+                    base: 'something'
+                }),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'one': new TempExtension()
+                    }
+                });
+
+            expect(editor.getExtensionByName('one')).toBeUndefined();
+            expect(editor.getExtensionByName('tempExtension').base).toBe('something');
+        });
+
+        it('should set the name of property of extensions', function () {
+            var ExtensionOne = function () {},
+                ExtensionTwo = function () {},
+                extOne = new ExtensionOne(),
+                extTwo = new ExtensionTwo(),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'one': extOne,
+                        'two': extTwo
+                    }
+                });
+
+            expect(extOne.name).toBe('one');
+            expect(extTwo.name).toBe('two');
+
+            expect(editor.getExtensionByName('one')).toBe(extOne);
+            expect(editor.getExtensionByName('two')).toBe(extTwo);
+        });
+
         it('should set window and document properties on each extension', function () {
             var TempExtension = MediumEditor.Extension.extend({}),
                 extInstance = new TempExtension(),
@@ -269,68 +329,6 @@ describe('Extensions TestCase', function () {
             expect(editor.toolbar.getToolbarElement().querySelectorAll('button[data-action="italic"]').length).toBe(1);
             expect(editor.toolbar.getToolbarElement().querySelectorAll('button[data-action="bold"]').length).toBe(0);
             expect(ext.init).toHaveBeenCalled();
-        });
-    });
-
-    describe('Set data in extensions', function () {
-        it('should set the base property to an instance of MediumEditor', function () {
-            var extOne = new MediumEditor.Extension(),
-                editor = this.newMediumEditor('.editor', {
-                    extensions: {
-                        'one': extOne
-                    }
-                });
-
-            expect(editor instanceof MediumEditor).toBeTruthy();
-            expect(extOne.base instanceof MediumEditor).toBeTruthy();
-        });
-
-        it('should not set the base property when deprecated parent attribute is set to false', function () {
-            var TempExtension = MediumEditor.Extension.extend({
-                    parent: false
-                }),
-                editor = this.newMediumEditor('.editor', {
-                    extensions: {
-                        'temp': new TempExtension()
-                    }
-                });
-
-            expect(editor instanceof MediumEditor).toBeTruthy();
-            expect(editor.getExtensionByName('temp').base).toBeUndefined();
-        });
-
-        it('should not override the base or name properties of an extension if overriden', function () {
-            var TempExtension = MediumEditor.Extension.extend({
-                    name: 'tempExtension',
-                    base: 'something'
-                }),
-                editor = this.newMediumEditor('.editor', {
-                    extensions: {
-                        'one': new TempExtension()
-                    }
-                });
-
-            expect(editor.getExtensionByName('one')).toBeUndefined();
-            expect(editor.getExtensionByName('tempExtension').base).toBe('something');
-        });
-
-        it('should set the name of property of extensions', function () {
-            var ExtensionOne = function () {},
-                ExtensionTwo = function () {},
-                extOne = new ExtensionOne(),
-                extTwo = new ExtensionTwo(),
-                editor = this.newMediumEditor('.editor', {
-                    extensions: {
-                        'one': extOne,
-                        'two': extTwo
-                    }
-                });
-
-            expect(extOne.name).toBe('one');
-            expect(extTwo.name).toBe('two');
-
-            expect(editor.getExtensionByName('one')).toBe(extOne);
-            expect(editor.getExtensionByName('two')).toBe(extTwo);
         });
     });
 });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -404,9 +404,9 @@ function MediumEditor(elements, options) {
         // Backwards compatability
         var defaultsBC = {
             hideDelay: this.options.anchorPreviewHideDelay, // deprecated
-            diffLeft: this.options.diffLeft,
-            diffTop: this.options.diffTop,
-            elementsContainer: this.options.elementsContainer
+            diffLeft: this.options.diffLeft, // deprecated (should use .getEditorOption() instead)
+            diffTop: this.options.diffTop, // deprecated (should use .getEditorOption() instead)
+            elementsContainer: this.options.elementsContainer // deprecated (should use .getEditorOption() instead)
         };
 
         return new MediumEditor.extensions.anchorPreview(
@@ -434,8 +434,8 @@ function MediumEditor(elements, options) {
         var defaultsBC = {
             forcePlainText: this.options.forcePlainText, // deprecated
             cleanPastedHTML: this.options.cleanPastedHTML, // deprecated
-            disableReturn: this.options.disableReturn,
-            targetBlank: this.options.targetBlank
+            disableReturn: this.options.disableReturn, // deprecated (should use .getEditorOption() instead)
+            targetBlank: this.options.targetBlank // deprecated (should use .getEditorOption() instead)
         };
 
         return new MediumEditor.extensions.paste(

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -5,6 +5,10 @@ var Extension;
     /* global Util */
 
     var passThroughHelpers = [
+        // general helpers
+        'execAction',
+
+        // event handling
         'on',
         'off',
         'subscribe'

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -4,16 +4,6 @@ var Extension;
 
     /* global Util */
 
-    var passThroughHelpers = [
-        // general helpers
-        'execAction',
-
-        // event handling
-        'on',
-        'off',
-        'subscribe'
-    ];
-
     Extension = function (options) {
         Util.extend(this, options);
     };
@@ -234,10 +224,27 @@ var Extension;
         }
     };
 
-    passThroughHelpers.forEach(function (helper) {
-        var methodName = helper;
-        Extension.prototype[methodName] = function () {
-            return this.base[methodName].apply(this.base, arguments);
+    /* List of method names to add to the prototype of Extension
+     * Each of these methods will be defined as helpers that
+     * just call directly into the MediumEditor instance.
+     *
+     * example for 'on' method:
+     * Extension.prototype.on = function () {
+     *     return this.base.on.apply(this.base, arguments);
+     * }
+     */
+    [
+        // general helpers
+        'execAction',
+
+        // event handling
+        'on',
+        'off',
+        'subscribe'
+
+    ].forEach(function (helper) {
+        Extension.prototype[helper] = function () {
+            return this.base[helper].apply(this.base, arguments);
         };
     });
 })();

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -6,7 +6,8 @@ var Extension;
 
     var passThroughHelpers = [
         'on',
-        'off'
+        'off',
+        'subscribe'
     ];
 
     Extension = function (options) {

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -4,6 +4,11 @@ var Extension;
 
     /* global Util */
 
+    var passThroughHelpers = [
+        'on',
+        'off'
+    ];
+
     Extension = function (options) {
         Util.extend(this, options);
     };
@@ -195,4 +200,11 @@ var Extension;
          */
         'document': undefined
     };
+
+    passThroughHelpers.forEach(function (helper) {
+        var methodName = helper;
+        Extension.prototype[methodName] = function () {
+            return this.base[methodName].apply(this.base, arguments);
+        };
+    });
 })();

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -203,7 +203,35 @@ var Extension;
          * passed via the 'ownerDocument' optin to MediumEditor
          * and is the global 'document' object by default
          */
-        'document': undefined
+        'document': undefined,
+
+        /* getEditorElements: [function ()]
+         *
+         * Helper function which returns an array containing
+         * all the contenteditable elements for this instance
+         * of MediumEditor
+         */
+        getEditorElements: function () {
+            return this.base.elements;
+        },
+
+        /* getEditorId: [function ()]
+         *
+         * Helper function which returns a unique identifier
+         * for this instance of MediumEditor
+         */
+        getEditorId: function () {
+            return this.base.id;
+        },
+
+        /* getEditorOptions: [function (option)]
+         *
+         * Helper function which returns the value of an option
+         * used to initialize this instance of MediumEditor
+         */
+        getEditorOption: function (option) {
+            return this.base.options[option];
+        }
     };
 
     passThroughHelpers.forEach(function (helper) {

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -48,7 +48,7 @@ var AnchorPreview;
             el.className = 'medium-editor-anchor-preview';
             el.innerHTML = this.getTemplate();
 
-            this.base.on(el, 'click', this.handleClick.bind(this));
+            this.on(el, 'click', this.handleClick.bind(this));
 
             return el;
         },
@@ -147,7 +147,7 @@ var AnchorPreview;
 
         handleAnchorMouseout: function () {
             this.anchorToPreview = null;
-            this.base.off(this.activeAnchor, 'mouseout', this.instanceHandleAnchorMouseout);
+            this.off(this.activeAnchor, 'mouseout', this.instanceHandleAnchorMouseout);
             this.instanceHandleAnchorMouseout = null;
         },
 
@@ -177,7 +177,7 @@ var AnchorPreview;
                 this.anchorToPreview = target;
 
                 this.instanceHandleAnchorMouseout = this.handleAnchorMouseout.bind(this);
-                this.base.on(this.anchorToPreview, 'mouseout', this.instanceHandleAnchorMouseout);
+                this.on(this.anchorToPreview, 'mouseout', this.instanceHandleAnchorMouseout);
                 // Using setTimeout + delay because:
                 // - We're going to show the anchor preview according to the configured delay
                 //   if the mouse has not left the anchor tag in that time
@@ -216,11 +216,11 @@ var AnchorPreview;
             // cleanup
             clearInterval(this.intervalTimer);
             if (this.instanceHandlePreviewMouseover) {
-                this.base.off(this.anchorPreview, 'mouseover', this.instanceHandlePreviewMouseover);
-                this.base.off(this.anchorPreview, 'mouseout', this.instanceHandlePreviewMouseout);
+                this.off(this.anchorPreview, 'mouseover', this.instanceHandlePreviewMouseover);
+                this.off(this.anchorPreview, 'mouseout', this.instanceHandlePreviewMouseout);
                 if (this.activeAnchor) {
-                    this.base.off(this.activeAnchor, 'mouseover', this.instanceHandlePreviewMouseover);
-                    this.base.off(this.activeAnchor, 'mouseout', this.instanceHandlePreviewMouseout);
+                    this.off(this.activeAnchor, 'mouseover', this.instanceHandlePreviewMouseover);
+                    this.off(this.activeAnchor, 'mouseout', this.instanceHandlePreviewMouseout);
                 }
             }
 
@@ -239,10 +239,10 @@ var AnchorPreview;
 
             this.intervalTimer = setInterval(this.updatePreview.bind(this), 200);
 
-            this.base.on(this.anchorPreview, 'mouseover', this.instanceHandlePreviewMouseover);
-            this.base.on(this.anchorPreview, 'mouseout', this.instanceHandlePreviewMouseout);
-            this.base.on(this.activeAnchor, 'mouseover', this.instanceHandlePreviewMouseover);
-            this.base.on(this.activeAnchor, 'mouseout', this.instanceHandlePreviewMouseout);
+            this.on(this.anchorPreview, 'mouseover', this.instanceHandlePreviewMouseover);
+            this.on(this.anchorPreview, 'mouseout', this.instanceHandlePreviewMouseout);
+            this.on(this.activeAnchor, 'mouseover', this.instanceHandlePreviewMouseover);
+            this.on(this.activeAnchor, 'mouseout', this.instanceHandlePreviewMouseout);
         }
     });
 }());

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -120,7 +120,7 @@ var AnchorPreview;
         },
 
         attachToEditables: function () {
-            this.base.subscribe('editableMouseover', this.handleEditableMouseover.bind(this));
+            this.subscribe('editableMouseover', this.handleEditableMouseover.bind(this));
         },
 
         handleClick: function (event) {

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -20,11 +20,9 @@ var AnchorPreview;
         previewValueSelector: 'a',
 
         /* ----- internal options needed from base ----- */
-        'window': window,
-        'document': document,
-        diffLeft: 0,
-        diffTop: -10,
-        elementsContainer: false,
+        diffLeft: 0, // deprecated (should use .getEditorOption() instead)
+        diffTop: -10, // deprecated (should use .getEditorOption() instead)
+        elementsContainer: false, // deprecated (should use .getEditorOption() instead)
 
         init: function () {
             this.anchorPreview = this.createPreview();
@@ -44,7 +42,7 @@ var AnchorPreview;
         createPreview: function () {
             var el = this.document.createElement('div');
 
-            el.id = 'medium-editor-anchor-preview-' + this.base.id;
+            el.id = 'medium-editor-anchor-preview-' + this.getEditorId();
             el.className = 'medium-editor-anchor-preview';
             el.innerHTML = this.getTemplate();
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -227,16 +227,16 @@ var AnchorForm;
                 input = form.querySelector('.medium-editor-toolbar-input');
 
             // Handle clicks on the form itself
-            this.base.on(form, 'click', this.handleFormClick.bind(this));
+            this.on(form, 'click', this.handleFormClick.bind(this));
 
             // Handle typing in the textbox
-            this.base.on(input, 'keyup', this.handleTextboxKeyup.bind(this));
+            this.on(input, 'keyup', this.handleTextboxKeyup.bind(this));
 
             // Handle close button clicks
-            this.base.on(close, 'click', this.handleCloseClick.bind(this));
+            this.on(close, 'click', this.handleCloseClick.bind(this));
 
             // Handle save button clicks (capture)
-            this.base.on(save, 'click', this.handleSaveClick.bind(this), true);
+            this.on(save, 'click', this.handleSaveClick.bind(this), true);
 
         },
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -41,10 +41,6 @@ var AnchorForm;
          */
         targetCheckboxText: 'Open in new window',
 
-        /* ----- internal options needed from base ----- */
-        'window': window,
-        'document': document,
-
         // Options for the Button base class
         name: 'anchor',
         action: 'createLink',
@@ -99,12 +95,12 @@ var AnchorForm;
 
             template.push(
                 '<a href="#" class="medium-editor-toolbar-save">',
-                this.base.options.buttonLabels === 'fontawesome' ? '<i class="fa fa-check"></i>' : this.formSaveLabel,
+                this.getEditorOption('buttonLabels') === 'fontawesome' ? '<i class="fa fa-check"></i>' : this.formSaveLabel,
                 '</a>'
             );
 
             template.push('<a href="#" class="medium-editor-toolbar-close">',
-                this.base.options.buttonLabels === 'fontawesome' ? '<i class="fa fa-times"></i>' : this.formCloseLabel,
+                this.getEditorOption('buttonLabels') === 'fontawesome' ? '<i class="fa fa-times"></i>' : this.formCloseLabel,
                 '</a>');
 
             // both of these options are slightly moot with the ability to
@@ -246,7 +242,7 @@ var AnchorForm;
 
             // Anchor Form (div)
             form.className = 'medium-editor-toolbar-form';
-            form.id = 'medium-editor-toolbar-form-anchor-' + this.base.id;
+            form.id = 'medium-editor-toolbar-form-anchor-' + this.getEditorId();
             form.innerHTML = this.getTemplate();
             this.attachFormEvents(form);
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -63,7 +63,7 @@ var AnchorForm;
             var selectedParentElement = Selection.getSelectedParentElement(Selection.getSelectionRange(this.document));
             if (selectedParentElement.tagName &&
                     selectedParentElement.tagName.toLowerCase() === 'a') {
-                return this.base.execAction('unlink');
+                return this.execAction('unlink');
             }
 
             if (!this.isDisplayed()) {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -201,7 +201,7 @@ var AnchorForm;
 
         completeFormSave: function (opts) {
             this.base.restoreSelection();
-            this.base.execAction(this.action, opts);
+            this.execAction(this.action, opts);
             this.base.checkSelection();
         },
 

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -32,8 +32,8 @@ LINK_REGEXP_TEXT =
 
         init: function () {
             this.disableEventHandling = false;
-            this.base.subscribe('editableKeypress', this.onKeypress.bind(this));
-            this.base.subscribe('editableBlur', this.onBlur.bind(this));
+            this.subscribe('editableKeypress', this.onKeypress.bind(this));
+            this.subscribe('editableBlur', this.onBlur.bind(this));
             // MS IE has it's own auto-URL detect feature but ours is better in some ways. Be consistent.
             this.document.execCommand('AutoUrlDetect', false, false);
         },

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -64,7 +64,7 @@ var Button;
 
                 action = this.getAction();
                 if (action) {
-                    this.base.execAction(action);
+                    this.execAction(action);
                 }
             }
         },
@@ -75,7 +75,7 @@ var Button;
             var action = this.getAction();
 
             if (action) {
-                this.base.execAction(action);
+                this.execAction(action);
             }
         },
         isActive: function () {

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -8,7 +8,7 @@ var Button;
 
         init: function () {
             this.button = this.createButton();
-            this.base.on(this.button, 'click', this.handleClick.bind(this));
+            this.on(this.button, 'click', this.handleClick.bind(this));
             if (this.key) {
                 this.base.subscribe('editableKeydown', this.handleKeydown.bind(this));
             }

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -36,7 +36,8 @@ var Button;
         createButton: function () {
             var button = this.document.createElement('button'),
                 content = this.contentDefault,
-                ariaLabel = this.getAria();
+                ariaLabel = this.getAria(),
+                buttonLabels = this.getEditorOption('buttonLabels');
             button.classList.add('medium-editor-action');
             button.classList.add('medium-editor-action-' + this.name);
             button.setAttribute('data-action', this.getAction());
@@ -44,11 +45,11 @@ var Button;
                 button.setAttribute('title', ariaLabel);
                 button.setAttribute('aria-label', ariaLabel);
             }
-            if (this.base.options.buttonLabels) {
-                if (this.base.options.buttonLabels === 'fontawesome' && this.contentFA) {
+            if (buttonLabels) {
+                if (buttonLabels === 'fontawesome' && this.contentFA) {
                     content = this.contentFA;
-                } else if (typeof this.base.options.buttonLabels === 'object' && this.base.options.buttonLabels[this.name]) {
-                    content = this.base.options.buttonLabels[this.name];
+                } else if (typeof buttonLabels === 'object' && buttonLabels[this.name]) {
+                    content = buttonLabels[this.name];
                 }
             }
             button.innerHTML = content;
@@ -79,14 +80,14 @@ var Button;
             }
         },
         isActive: function () {
-            return this.button.classList.contains(this.base.options.activeButtonClass);
+            return this.button.classList.contains(this.getEditorOption('activeButtonClass'));
         },
         setInactive: function () {
-            this.button.classList.remove(this.base.options.activeButtonClass);
+            this.button.classList.remove(this.getEditorOption('activeButtonClass'));
             delete this.knownState;
         },
         setActive: function () {
-            this.button.classList.add(this.base.options.activeButtonClass);
+            this.button.classList.add(this.getEditorOption('activeButtonClass'));
             delete this.knownState;
         },
         queryCommandState: function () {

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -10,7 +10,7 @@ var Button;
             this.button = this.createButton();
             this.on(this.button, 'click', this.handleClick.bind(this));
             if (this.key) {
-                this.base.subscribe('editableKeydown', this.handleKeydown.bind(this));
+                this.subscribe('editableKeydown', this.handleKeydown.bind(this));
             }
         },
 

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -97,7 +97,7 @@ var FontSizeForm;
             form.id = 'medium-editor-toolbar-form-fontsize-' + this.base.id;
 
             // Handle clicks on the form itself
-            this.base.on(form, 'click', this.handleFormClick.bind(this));
+            this.on(form, 'click', this.handleFormClick.bind(this));
 
             // Add font size slider
             input.setAttribute('type', 'range');
@@ -107,7 +107,7 @@ var FontSizeForm;
             form.appendChild(input);
 
             // Handle typing in the textbox
-            this.base.on(input, 'change', this.handleSliderChange.bind(this));
+            this.on(input, 'change', this.handleSliderChange.bind(this));
 
             // Add save buton
             save.setAttribute('href', '#');
@@ -118,7 +118,7 @@ var FontSizeForm;
             form.appendChild(save);
 
             // Handle save button clicks (capture)
-            this.base.on(save, 'click', this.handleSaveClick.bind(this), true);
+            this.on(save, 'click', this.handleSaveClick.bind(this), true);
 
             // Add close button
             close.setAttribute('href', '#');
@@ -129,7 +129,7 @@ var FontSizeForm;
             form.appendChild(close);
 
             // Handle close button clicks
-            this.base.on(close, 'click', this.handleCloseClick.bind(this));
+            this.on(close, 'click', this.handleCloseClick.bind(this));
 
             return form;
         },

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -151,7 +151,7 @@ var FontSizeForm;
             if (size === '4') {
                 this.clearFontSize();
             } else {
-                this.base.execAction('fontSize', { size: size });
+                this.execAction('fontSize', { size: size });
             }
         },
 

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -94,7 +94,7 @@ var FontSizeForm;
 
             // Font Size Form (div)
             form.className = 'medium-editor-toolbar-form';
-            form.id = 'medium-editor-toolbar-form-fontsize-' + this.base.id;
+            form.id = 'medium-editor-toolbar-form-fontsize-' + this.getEditorId();
 
             // Handle clicks on the form itself
             this.on(form, 'click', this.handleFormClick.bind(this));
@@ -112,7 +112,7 @@ var FontSizeForm;
             // Add save buton
             save.setAttribute('href', '#');
             save.className = 'medium-editor-toobar-save';
-            save.innerHTML = this.base.options.buttonLabels === 'fontawesome' ?
+            save.innerHTML = this.getEditorOption('buttonLabels') === 'fontawesome' ?
                              '<i class="fa fa-check"></i>' :
                              '&#10003;';
             form.appendChild(save);
@@ -123,7 +123,7 @@ var FontSizeForm;
             // Add close button
             close.setAttribute('href', '#');
             close.className = 'medium-editor-toobar-close';
-            close.innerHTML = this.base.options.buttonLabels === 'fontawesome' ?
+            close.innerHTML = this.getEditorOption('buttonLabels') === 'fontawesome' ?
                               '<i class="fa fa-times"></i>' :
                               '&times;';
             form.appendChild(close);

--- a/src/js/extensions/image-dragging.js
+++ b/src/js/extensions/image-dragging.js
@@ -7,8 +7,8 @@ var ImageDragging;
     ImageDragging = Extension.extend({
 
         init: function () {
-            this.base.subscribe('editableDrag', this.handleDrag.bind(this));
-            this.base.subscribe('editableDrop', this.handleDrop.bind(this));
+            this.subscribe('editableDrag', this.handleDrag.bind(this));
+            this.subscribe('editableDrop', this.handleDrop.bind(this));
         },
 
         handleDrag: function (event) {

--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -87,7 +87,7 @@ var PasteHandler;
 
         init: function () {
             if (this.forcePlainText || this.cleanPastedHTML) {
-                this.base.subscribe('editablePaste', this.handlePaste.bind(this));
+                this.subscribe('editablePaste', this.handlePaste.bind(this));
             }
         },
 

--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -80,10 +80,8 @@ var PasteHandler;
         cleanTags: ['meta'],
 
         /* ----- internal options needed from base ----- */
-        'window': window,
-        'document': document,
-        targetBlank: false,
-        disableReturn: false,
+        targetBlank: false, // deprecated (should use .getEditorOption() instead)
+        disableReturn: false, // deprecated (should use .getEditorOption() instead)
 
         init: function () {
             if (this.forcePlainText || this.cleanPastedHTML) {

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -26,7 +26,7 @@ var Placeholder;
         },
 
         initPlaceholders: function () {
-            this.base.elements.forEach(function (el) {
+            this.getEditorElements().forEach(function (el) {
                 if (!el.getAttribute('data-placeholder')) {
                     el.setAttribute('data-placeholder', this.text);
                 }

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -57,21 +57,21 @@ var Placeholder;
 
         attachEventHandlers: function () {
             // Custom events
-            this.base.subscribe('blur', this.handleExternalInteraction.bind(this));
+            this.subscribe('blur', this.handleExternalInteraction.bind(this));
 
             // Check placeholder on blur
-            this.base.subscribe('editableBlur', this.handleBlur.bind(this));
+            this.subscribe('editableBlur', this.handleBlur.bind(this));
 
             // if we don't want the placeholder to be removed on click but when user start typing
             if (this.hideOnClick) {
-                this.base.subscribe('editableClick', this.handleHidePlaceholderEvent.bind(this));
+                this.subscribe('editableClick', this.handleHidePlaceholderEvent.bind(this));
             } else {
-                this.base.subscribe('editableKeyup', this.handleBlur.bind(this));
+                this.subscribe('editableKeyup', this.handleBlur.bind(this));
             }
 
             // Events where we always hide the placeholder
-            this.base.subscribe('editableKeypress', this.handleHidePlaceholderEvent.bind(this));
-            this.base.subscribe('editablePaste', this.handleHidePlaceholderEvent.bind(this));
+            this.subscribe('editableKeypress', this.handleHidePlaceholderEvent.bind(this));
+            this.subscribe('editablePaste', this.handleHidePlaceholderEvent.bind(this));
         },
 
         handleHidePlaceholderEvent: function (event, element) {


### PR DESCRIPTION
This PR adds some helper methods to all extensions, including accessors into MediumEditor methods + properties.  There are also some minor changes to cleanup tests and remove unneeded defaults from extensions.

* `.on()` + `.off()` -> helpers that call directly into `MediumEditor.on()` + `MediumEditor.off()`
* `.subscribe()` -> calls directly into `MediumEditor.subscribe()`
* `.execAction()` -> calls directly into `MediumEditor.execAction()`
* `.getEditorElements()` + `.getEditorId()` -> accessors for MediumEditor's array of elements and unique id (respectively)
* `.getEditorOption()` -> accessor for specific MediumEditor options