### PR TITLE
Fix issue where elements array is lost after destroy

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -33,8 +33,8 @@ describe('Initialization TestCase', function () {
         it('should do nothing when selector does not return any elements', function () {
             spyOn(MediumEditor.prototype, 'setup');
             var editor = this.newMediumEditor('.test');
-            expect(editor.id).toBe(undefined);
-            expect(editor.setup).not.toHaveBeenCalled();
+            expect(editor.isActive).toBeFalsy();
+            expect(editor.events).toBeUndefined();
             expect(editor.toolbar).toBeUndefined();
             expect(editor.getExtensionByName('anchor')).toBeUndefined();
             expect(editor.getExtensionByName('anchor-preview')).toBeUndefined();
@@ -84,6 +84,15 @@ describe('Initialization TestCase', function () {
             expect(editor.elements).not.toBe(null);
             expect(editor.elements.length).toBe(0);
             editor.destroy();
+        });
+
+        it('should be available after destroying and calling setup again', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements.length).toBe(1);
+            editor.destroy();
+            expect(editor.elements.length).toBe(0);
+            editor.setup();
+            expect(editor.elements.length).toBe(1);
         });
     });
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -588,10 +588,7 @@ function MediumEditor(elements, options) {
             var uniqueId = 1;
 
             this.options = mergeOptions.call(this, this.defaults, options);
-            createElementsArray.call(this, elements);
-            if (this.elements.length === 0) {
-                return;
-            }
+            this.origElements = elements;
 
             if (!this.options.elementsContainer) {
                 this.options.elementsContainer = this.options.ownerDocument.body;
@@ -608,6 +605,11 @@ function MediumEditor(elements, options) {
 
         setup: function () {
             if (this.isActive) {
+                return;
+            }
+
+            createElementsArray.call(this, this.origElements);
+            if (this.elements.length === 0) {
                 return;
             }
 


### PR DESCRIPTION
This fixes issue called out in issue #634 

The elements array is emptied after calling `destroy()`, however this means that calls to `setup()` afterwards will not have any elements and thus the editor will be useless.

The fix is to store the selector passed in during initialization, and re-use this same list each time `setup()` is called.