### PR TITLE
destroy() for extensions

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -178,7 +178,7 @@ describe('Anchor Preview TestCase', function () {
             var editor = this.newMediumEditor('.editor'),
                 anchorPreview = editor.getExtensionByName('anchor-preview');
 
-            spyOn(AnchorPreview.prototype, 'deactivate').and.callThrough();
+            spyOn(AnchorPreview.prototype, 'destroy').and.callThrough();
             expect(document.querySelector('.medium-editor-anchor-preview')).not.toBeNull();
             expect(document.querySelector('.medium-editor-anchor-preview-active')).toBeNull();
 
@@ -190,7 +190,7 @@ describe('Anchor Preview TestCase', function () {
 
             // destroy
             editor.destroy();
-            expect(anchorPreview.deactivate).toHaveBeenCalled();
+            expect(anchorPreview.destroy).toHaveBeenCalled();
             expect(document.querySelector('.medium-editor-anchor-preview-active')).toBeNull();
             expect(document.querySelector('.medium-editor-anchor-preview')).toBeNull();
         });

--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -5,6 +5,59 @@
 describe('Autolink', function () {
     'use strict';
 
+    describe('extension', function () {
+
+        beforeEach(function () {
+            setupTestHelpers.call(this);
+            this.el = this.createElement('div', 'editor', '');
+        });
+
+        afterEach(function () {
+            this.cleanupTest();
+        });
+
+        it('should turn off browser auto-link during initialization', function () {
+            var autoUrlDetectTurnedOn = true,
+                origExecCommand = document.execCommand;
+            spyOn(document, 'execCommand').and.callFake(function (command, showUi, val) {
+                if (command === 'AutoUrlDetect') {
+                    autoUrlDetectTurnedOn = val;
+                }
+                return origExecCommand.apply(document, arguments);
+            });
+            this.newMediumEditor('.editor', {
+                autoLink: true
+            });
+            expect(autoUrlDetectTurnedOn).toBe(false);
+        });
+
+        it('should reset browser auto-link (if supported) during destroy', function () {
+            var autoUrlDetectTurnedOn = true,
+                origExecCommand = document.execCommand,
+                origQCS = document.queryCommandSupported;
+            spyOn(document, 'execCommand').and.callFake(function (command, showUi, val) {
+                if (command === 'AutoUrlDetect') {
+                    autoUrlDetectTurnedOn = val;
+                }
+                return origExecCommand.apply(document, arguments);
+            });
+            spyOn(document, 'queryCommandSupported').and.callFake(function (command) {
+                if (command === 'AutoUrlDetect') {
+                    return true;
+                }
+                return origQCS.apply(document, arguments);
+            });
+
+            var editor = this.newMediumEditor('.editor', {
+                autoLink: true
+            });
+
+            expect(autoUrlDetectTurnedOn).toBe(false);
+            editor.destroy();
+            expect(autoUrlDetectTurnedOn).toBe(true);
+        });
+    });
+
     describe('integration', function () {
 
         beforeEach(function () {

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -174,6 +174,36 @@ describe('Extensions TestCase', function () {
             expect(extInstance.window).toBe(fakeWindow);
             expect(extInstance.document).toBe(fakeDocument);
         });
+
+        it('should call destroy on extensions when being destroyed', function () {
+            var TempExtension = MediumEditor.Extension.extend({
+                    destroy: function () {}
+                }),
+                extInstance = new TempExtension();
+            spyOn(extInstance, 'destroy');
+            var editor = this.newMediumEditor('.editor', {
+                extensions: {
+                    'temp-extension': extInstance
+                }
+            });
+            editor.destroy();
+            expect(extInstance.destroy).toHaveBeenCalled();
+        });
+
+        it('should call deprecated deactivate on extensions when being destroyed if destroy is not implemented', function () {
+            var TempExtension = MediumEditor.Extension.extend({
+                    deactivate: function () {}
+                }),
+                extInstance = new TempExtension();
+            spyOn(extInstance, 'deactivate');
+            var editor = this.newMediumEditor('.editor', {
+                extensions: {
+                    'temp-extension': extInstance
+                }
+            });
+            editor.destroy();
+            expect(extInstance.deactivate).toHaveBeenCalled();
+        });
     });
 
     describe('Core Extension', function () {

--- a/spec/fontsize.spec.js
+++ b/spec/fontsize.spec.js
@@ -136,15 +136,15 @@ describe('Font Size Button TestCase', function () {
     });
 
     describe('Destroying MediumEditor', function () {
-        it('should deactivate the font size extension and remove the form', function () {
-            spyOn(FontSizeForm.prototype, 'deactivate').and.callThrough();
+        it('should destroy the font size extension and remove the form', function () {
+            spyOn(FontSizeForm.prototype, 'destroy').and.callThrough();
             var editor = this.newMediumEditor('.editor', this.mediumOpts),
                 fontSizeExtension = editor.getExtensionByName('fontsize');
 
             expect(document.getElementById('medium-editor-toolbar-form-fontsize-1')).toBeTruthy();
             editor.destroy();
 
-            expect(fontSizeExtension.deactivate).toHaveBeenCalled();
+            expect(fontSizeExtension.destroy).toHaveBeenCalled();
             expect(document.getElementById('medium-editor-toolbar-form-fontsize-1')).not.toBeTruthy();
         });
     });

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -121,6 +121,27 @@ describe('Placeholder TestCase', function () {
         validatePlaceholderContent(editor.elements[0], Placeholder.prototype.text);
     });
 
+    it('should remove the added data-placeholder attribute when destroyed', function () {
+        expect(this.el.hasAttribute('data-placeholder')).toBe(false);
+
+        var editor = this.newMediumEditor('.editor');
+        expect(this.el.getAttribute('data-placeholder')).toBe(Placeholder.prototype.text);
+
+        editor.destroy();
+        expect(this.el.hasAttribute('data-placeholder')).toBe(false);
+    });
+
+    it('should not remove custom data-placeholder attribute when destroyed', function () {
+        var placeholderText = 'Custom placeholder';
+        this.el.setAttribute('data-placeholder', placeholderText);
+
+        var editor = this.newMediumEditor('.editor');
+        expect(this.el.getAttribute('data-placeholder')).toBe(placeholderText);
+
+        editor.destroy();
+        expect(this.el.getAttribute('data-placeholder')).toBe(placeholderText);
+    });
+
     it('should use the data-placeholder when it is present', function () {
         var editor,
             placeholderText = 'Custom placeholder';

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -631,7 +631,7 @@ function MediumEditor(elements, options) {
             this.isActive = false;
 
             if (this.toolbar !== undefined) {
-                this.toolbar.deactivate();
+                this.toolbar.destroy();
                 delete this.toolbar;
             }
 
@@ -655,7 +655,11 @@ function MediumEditor(elements, options) {
             this.elements = [];
 
             this.commands.forEach(function (extension) {
+                if (typeof extension.destroy === 'function') {
+                    extension.destroy();
+                }
                 if (typeof extension.deactivate === 'function') {
+                    Util.warn('Extension .deactivate() function has been deprecated. Use .destroy() instead. This will be removed in version 5.0.0');
                     extension.deactivate();
                 }
             }, this);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -630,6 +630,15 @@ function MediumEditor(elements, options) {
 
             this.isActive = false;
 
+            this.commands.forEach(function (extension) {
+                if (typeof extension.destroy === 'function') {
+                    extension.destroy();
+                } else if (typeof extension.deactivate === 'function') {
+                    Util.warn('Extension .deactivate() function has been deprecated. Use .destroy() instead. This will be removed in version 5.0.0');
+                    extension.deactivate();
+                }
+            }, this);
+
             if (this.toolbar !== undefined) {
                 this.toolbar.destroy();
                 delete this.toolbar;
@@ -653,16 +662,6 @@ function MediumEditor(elements, options) {
                 }
             }, this);
             this.elements = [];
-
-            this.commands.forEach(function (extension) {
-                if (typeof extension.destroy === 'function') {
-                    extension.destroy();
-                }
-                if (typeof extension.deactivate === 'function') {
-                    Util.warn('Extension .deactivate() function has been deprecated. Use .destroy() instead. This will be removed in version 5.0.0');
-                    extension.deactivate();
-                }
-            }, this);
 
             this.events.destroy();
         },

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -68,7 +68,7 @@ var Events;
             var index = this.indexOfCustomListener(event, listener);
             if (index !== -1) {
                 this.customEvents[event].splice(index, 1);
-                // TODO: If array is empty, should detach internal listeners via destoryListener()
+                // TODO: If array is empty, should detach internal listeners via destroyListener()
             }
         },
 

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -117,6 +117,15 @@ var Extension;
          */
         checkState: undefined,
 
+        /* destroy: [function ()]
+         *
+         * This method should remove any created html, custom event handlers
+         * or any other cleanup tasks that should be performed.
+         * If implemented, this function will be called when MediumEditor's
+         * destroy method has been called.
+         */
+        destroy: undefined,
+
         /* As alternatives to checkState, these functions provide a more structured
          * path to updating the state of an extension (usually a button) whenever
          * the state of the editor & toolbar are updated.

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -4,16 +4,6 @@ var Extension;
 
     /* global Util */
 
-    var passThroughHelpers = [
-        // general helpers
-        'execAction',
-
-        // event handling
-        'on',
-        'off',
-        'subscribe'
-    ];
-
     Extension = function (options) {
         Util.extend(this, options);
     };

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -4,6 +4,16 @@ var Extension;
 
     /* global Util */
 
+    var passThroughHelpers = [
+        // general helpers
+        'execAction',
+
+        // event handling
+        'on',
+        'off',
+        'subscribe'
+    ];
+
     Extension = function (options) {
         Util.extend(this, options);
     };

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -57,13 +57,18 @@ var AnchorPreview;
                 '</div>';
         },
 
-        deactivate: function () {
+        destroy: function () {
             if (this.anchorPreview) {
                 if (this.anchorPreview.parentNode) {
                     this.anchorPreview.parentNode.removeChild(this.anchorPreview);
                 }
                 delete this.anchorPreview;
             }
+        },
+
+        // TODO: deprecate
+        deactivate: function () {
+            Util.deprecatedMethod.call(this, 'deactivate', 'destroy', arguments, 'v5.0.0');
         },
 
         hidePreview: function () {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -154,8 +154,8 @@ var AnchorForm;
             input.focus();
         },
 
-        // Called by core when tearing down medium-editor (deactivate)
-        deactivate: function () {
+        // Called by core when tearing down medium-editor (destroy)
+        destroy: function () {
             if (!this.form) {
                 return false;
             }
@@ -165,6 +165,11 @@ var AnchorForm;
             }
 
             delete this.form;
+        },
+
+        // TODO: deprecate
+        deactivate: function () {
+            Util.deprecatedMethod.call(this, 'deactivate', 'destroy', arguments, 'v5.0.0');
         },
 
         // core methods

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -38,6 +38,13 @@ LINK_REGEXP_TEXT =
             this.document.execCommand('AutoUrlDetect', false, false);
         },
 
+        destroy: function () {
+            // Turn AutoUrlDetect back on
+            if (this.document.queryCommandSupported('AutoUrlDetect')) {
+                this.document.execCommand('AutoUrlDetect', false, true);
+            }
+        },
+
         onBlur: function (blurEvent, editable) {
             this.performLinking(editable);
         },

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -2,7 +2,7 @@ var FontSizeForm;
 (function () {
     'use strict';
 
-    /*global FormExtension, Selection */
+    /*global FormExtension, Selection, Util */
 
     FontSizeForm = FormExtension.extend({
 

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -57,8 +57,8 @@ var FontSizeForm;
             input.focus();
         },
 
-        // Called by core when tearing down medium-editor (deactivate)
-        deactivate: function () {
+        // Called by core when tearing down medium-editor (destroy)
+        destroy: function () {
             if (!this.form) {
                 return false;
             }
@@ -68,6 +68,11 @@ var FontSizeForm;
             }
 
             delete this.form;
+        },
+
+        // TODO: deprecate
+        deactivate: function () {
+            Util.deprecatedMethod.call(this, 'deactivate', 'destroy', arguments, 'v5.0.0');
         },
 
         // core methods

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -34,6 +34,14 @@ var Placeholder;
             }, this);
         },
 
+        destroy: function () {
+            this.getEditorElements().forEach(function (el) {
+                if (el.getAttribute('data-placeholder') === this.text) {
+                    el.removeAttribute('data-placeholder');
+                }
+            }, this);
+        },
+
         showPlaceholder: function (el) {
             if (el) {
                 el.classList.add('medium-editor-placeholder');

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -76,13 +76,18 @@ var Toolbar;
             return ul;
         },
 
-        deactivate: function () {
+        destroy: function () {
             if (this.toolbar) {
                 if (this.toolbar.parentNode) {
                     this.toolbar.parentNode.removeChild(this.toolbar);
                 }
                 delete this.toolbar;
             }
+        },
+
+        // TODO: deprecate
+        deactivate: function () {
+            Util.deprecatedMethod.call(this, 'deactivate', 'destroy', arguments, 'v5.0.0');
         },
 
         // Toolbar accessors


### PR DESCRIPTION
This PR deprecates the `deactivate()` method on extension and standardizes on the `destroy()` method.  It also implements `destroy()` for auto-link and placeholder extensions.