### PR TITLE
Ask users to not commit dist files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Test your changes to the best of your ability.
 4. Update the documentation to reflect your changes if they add or changes current functionality.
-5. Commit your changes (`git commit -am 'Added some feature'`)
+5. Commit your changes (`git commit -am 'Added some feature'`) **without files from the _dist_ directory**.
 6. Push to the branch (`git push origin my-new-feature`)
 7. Create new Pull Request
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ The source files are located inside the __src__ directory.  Be sure to make chan
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Test your changes to the best of your ability.
 4. Update the documentation to reflect your changes if they add or changes current functionality.
-5. Commit your changes (`git commit -am 'Added some feature'`)
+5. Commit your changes (`git commit -am 'Added some feature'`) **without files from the _dist_ directory**.
 6. Push to the branch (`git push origin my-new-feature`)
 7. Create new Pull Request
 


### PR DESCRIPTION
Like I said on Gitter, I would like to update CONTRIBUTING to specify that user who forks and then create a PR **shouldn't** commit the _dist_ directory.

This will ease all merge requests and then we just need to build these files on our own when we need to cut a new release.

I don't know if the message is clear enough in the README / CONTRIBUTING. What do you think?