### PR TITLE
Create Util.key to return key code from an event

### DIFF
--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -342,4 +342,31 @@ describe('Util', function () {
             expect(result).toBe(false);
         });
     });
+
+    describe('isKey', function () {
+        it('should return the key from the event', function () {
+            var event;
+
+            event = {
+                which: 13,
+                keyCode: null,
+                charCode: null
+            };
+            expect(Util.isKey(event, 13)).toBeTruthy();
+
+            event = {
+                which: null,
+                keyCode: 13,
+                charCode: null
+            };
+            expect(Util.isKey(event, [13, 12])).toBeTruthy();
+
+            event = {
+                which: null,
+                keyCode: null,
+                charCode: 13
+            };
+            expect(Util.isKey(event, [65])).toBeFalsy();
+        });
+    });
 });

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -344,7 +344,7 @@ describe('Util', function () {
     });
 
     describe('isKey', function () {
-        it('should return the key from the event', function () {
+        it('should return true no matter how the key associated to the event is defined', function () {
             var event;
 
             event = {
@@ -359,14 +359,35 @@ describe('Util', function () {
                 keyCode: 13,
                 charCode: null
             };
-            expect(Util.isKey(event, [13, 12])).toBeTruthy();
+            expect(Util.isKey(event, 13)).toBeTruthy();
 
             event = {
                 which: null,
                 keyCode: null,
                 charCode: 13
             };
+            expect(Util.isKey(event, 13)).toBeTruthy();
+        });
+
+        it('should return true when a key associated to event is listed to one we are looking for', function () {
+            var event = {
+                which: 13
+            };
+
+            expect(Util.isKey(event, 13)).toBeTruthy();
+            expect(Util.isKey(event, [13])).toBeTruthy();
+            expect(Util.isKey(event, [13, 12])).toBeTruthy();
+            expect(Util.isKey(event, [12, 13])).toBeTruthy();
+        });
+
+        it('should return false when a key associated to event is NOT listed to one we are looking for', function () {
+            var event = {
+                which: 13
+            };
+
+            expect(Util.isKey(event, 65)).toBeFalsy();
             expect(Util.isKey(event, [65])).toBeFalsy();
+            expect(Util.isKey(event, [65, 66])).toBeFalsy();
         });
     });
 });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -56,20 +56,20 @@ function MediumEditor(elements, options) {
             isEmpty = /^(\s+|<br\/?>)?$/i,
             isHeader = /h\d/i;
 
-        if ((event.which === Util.keyCode.BACKSPACE || event.which === Util.keyCode.ENTER) &&
+        if (Util.isKey(event, [Util.keyCode.BACKSPACE, Util.keyCode.ENTER]) &&
                 // has a preceeding sibling
                 node.previousElementSibling &&
                 // in a header
                 isHeader.test(tagName) &&
                 // at the very end of the block
                 Selection.getCaretOffsets(node).left === 0) {
-            if (event.which === Util.keyCode.BACKSPACE && isEmpty.test(node.previousElementSibling.innerHTML)) {
+            if (Util.isKey(event, Util.keyCode.BACKSPACE) && isEmpty.test(node.previousElementSibling.innerHTML)) {
                 // backspacing the begining of a header into an empty previous element will
                 // change the tagName of the current node to prevent one
                 // instead delete previous node and cancel the event.
                 node.previousElementSibling.parentNode.removeChild(node.previousElementSibling);
                 event.preventDefault();
-            } else if (event.which === Util.keyCode.ENTER) {
+            } else if (Util.isKey(event, Util.keyCode.ENTER)) {
                 // hitting return in the begining of a header will create empty header elements before the current one
                 // instead, make "<p><br></p>" element, which are what happens if you hit return in an empty paragraph
                 p = this.options.ownerDocument.createElement('p');
@@ -77,7 +77,7 @@ function MediumEditor(elements, options) {
                 node.previousElementSibling.parentNode.insertBefore(p, node);
                 event.preventDefault();
             }
-        } else if (event.which === Util.keyCode.DELETE &&
+        } else if (Util.isKey(event, Util.keyCode.DELETE) &&
                     // between two sibling elements
                     node.nextElementSibling &&
                     node.previousElementSibling &&
@@ -98,7 +98,7 @@ function MediumEditor(elements, options) {
             node.previousElementSibling.parentNode.removeChild(node);
 
             event.preventDefault();
-        } else if (event.which === Util.keyCode.BACKSPACE &&
+        } else if (Util.isKey(event, Util.keyCode.BACKSPACE) &&
                 tagName === 'li' &&
                 // hitting backspace inside an empty li
                 isEmpty.test(node.innerHTML) &&
@@ -144,7 +144,7 @@ function MediumEditor(elements, options) {
             this.options.ownerDocument.execCommand('formatBlock', false, 'p');
         }
 
-        if (event.which === Util.keyCode.ENTER && !Util.isListItem(node)) {
+        if (Util.isKey(event, Util.keyCode.ENTER) && !Util.isListItem(node)) {
             tagName = node.tagName.toLowerCase();
             // For anchor tags, unlink
             if (tagName === 'a') {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -581,7 +581,6 @@ function MediumEditor(elements, options) {
     MediumEditor.selection = Selection;
 
     MediumEditor.prototype = {
-
         defaults: editorDefaults,
 
         // NOT DOCUMENTED - exposed for backwards compatability

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -500,17 +500,16 @@ var Events;
         handleKeydown: function (event) {
             this.triggerCustomEvent('editableKeydown', event, event.currentTarget);
 
-            switch (event.which) {
-                case Util.keyCode.ENTER:
-                    this.triggerCustomEvent('editableKeydownEnter', event, event.currentTarget);
-                    break;
-                case Util.keyCode.TAB:
-                    this.triggerCustomEvent('editableKeydownTab', event, event.currentTarget);
-                    break;
-                case Util.keyCode.DELETE:
-                case Util.keyCode.BACKSPACE:
-                    this.triggerCustomEvent('editableKeydownDelete', event, event.currentTarget);
-                    break;
+            if (Util.isKey(event, Util.keyCode.ENTER)) {
+                return this.triggerCustomEvent('editableKeydownEnter', event, event.currentTarget);
+            }
+
+            if (Util.isKey(event, Util.keyCode.TAB)) {
+                return this.triggerCustomEvent('editableKeydownTab', event, event.currentTarget);
+            }
+
+            if (Util.isKey(event, [Util.keyCode.DELETE, Util.keyCode.BACKSPACE])) {
+                return this.triggerCustomEvent('editableKeydownDelete', event, event.currentTarget);
             }
         }
     };

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -162,17 +162,19 @@ var Events;
             var wrapper = function (aCommandName, aShowDefaultUI, aValueArgument) {
                 var result = doc.execCommand.orig.apply(this, arguments);
 
-                if (doc.execCommand.listeners) {
-                    var args = Array.prototype.slice.call(arguments);
-                    doc.execCommand.listeners.forEach(function (listener) {
-                        listener({
-                            command: aCommandName,
-                            value: aValueArgument,
-                            args: args,
-                            result: result
-                        });
-                    });
+                if (!doc.execCommand.listeners) {
+                    return result;
                 }
+
+                var args = Array.prototype.slice.call(arguments);
+                doc.execCommand.listeners.forEach(function (listener) {
+                    listener({
+                        command: aCommandName,
+                        value: aValueArgument,
+                        args: args,
+                        result: result
+                    });
+                });
 
                 return result;
             };
@@ -406,8 +408,7 @@ var Events;
             // to document, since this is where the event is handled
             // However, currentTarget will have an 'activeElement' property
             // which will point to whatever element has focus.
-            if (event.currentTarget &&
-                event.currentTarget.activeElement) {
+            if (event.currentTarget && event.currentTarget.activeElement) {
                 var activeElement = event.currentTarget.activeElement,
                     currentTarget;
                 // We can look at the 'activeElement' to determine if the selectionchange has

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -51,9 +51,9 @@ var AnchorForm;
 
         // Called when the button the toolbar is clicked
         // Overrides ButtonExtension.handleClick
-        handleClick: function (evt) {
-            evt.preventDefault();
-            evt.stopPropagation();
+        handleClick: function (event) {
+            event.preventDefault();
+            event.stopPropagation();
 
             var selectedParentElement = Selection.getSelectedParentElement(Selection.getSelectionRange(this.document));
             if (selectedParentElement.tagName &&
@@ -70,11 +70,9 @@ var AnchorForm;
 
         // Called when user hits the defined shortcut (CTRL / COMMAND + K)
         // Overrides Button.handleKeydown
-        handleKeydown: function (evt) {
-            var key = String.fromCharCode(evt.which || evt.keyCode).toLowerCase();
-
-            if (this.key === key && Util.isMetaCtrlKey(evt)) {
-                this.handleClick(evt);
+        handleKeydown: function (event) {
+            if (Util.isKey(event, this.key.charCodeAt(0)) && Util.isMetaCtrlKey(event)) {
+                this.handleClick(event);
             }
         },
 

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -53,10 +53,7 @@ LINK_REGEXP_TEXT =
                 return;
             }
 
-            if (keyPressEvent.keyCode === Util.keyCode.SPACE ||
-                keyPressEvent.keyCode === Util.keyCode.ENTER ||
-                keyPressEvent.which === Util.keyCode.SPACE ||
-                keyPressEvent.which === Util.keyCode.ENTER) {
+            if (Util.isKey(keyPressEvent, [Util.keyCode.SPACE, Util.keyCode.ENTER])) {
                 clearTimeout(this.performLinkingTimeout);
                 // Saving/restoring the selection in the middle of a keypress doesn't work well...
                 this.performLinkingTimeout = setTimeout(function () {

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -59,13 +59,12 @@ var Button;
             return button;
         },
 
-        handleKeydown: function (evt) {
-            var key = String.fromCharCode(evt.which || evt.keyCode).toLowerCase(),
-                action;
+        handleKeydown: function (event) {
+            var action;
 
-            if (this.key === key && Util.isMetaCtrlKey(evt)) {
-                evt.preventDefault();
-                evt.stopPropagation();
+            if (Util.isKey(event, this.key.charCodeAt(0)) && Util.isMetaCtrlKey(event)) {
+                event.preventDefault();
+                event.stopPropagation();
 
                 action = this.getAction();
                 if (action) {
@@ -74,9 +73,9 @@ var Button;
             }
         },
 
-        handleClick: function (evt) {
-            evt.preventDefault();
-            evt.stopPropagation();
+        handleClick: function (event) {
+            event.preventDefault();
+            event.stopPropagation();
 
             var action = this.getAction();
 

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -309,39 +309,41 @@ var Toolbar;
         },
 
         checkState: function () {
-            if (!this.base.preventSelectionUpdates) {
-                // If no editable has focus OR selection is inside contenteditable = false
-                // hide toolbar
-                if (!this.base.getFocusedElement() ||
-                        Selection.selectionInContentEditableFalse(this.options.contentWindow)) {
-                    return this.hideToolbar();
-                }
-
-                // If there's no selection element, selection element doesn't belong to this editor
-                // or toolbar is disabled for this selection element
-                // hide toolbar
-                var selectionElement = Selection.getSelectionElement(this.options.contentWindow);
-                if (!selectionElement ||
-                        this.base.elements.indexOf(selectionElement) === -1 ||
-                        selectionElement.getAttribute('data-disable-toolbar')) {
-                    return this.hideToolbar();
-                }
-
-                // Now we know there's a focused editable with a selection
-
-                // If the updateOnEmptySelection option is true, show the toolbar
-                if (this.options.updateOnEmptySelection && this.options.staticToolbar) {
-                    return this.showAndUpdateToolbar();
-                }
-
-                // If we don't have a 'valid' selection -> hide toolbar
-                if (this.options.contentWindow.getSelection().toString().trim() === '' ||
-                    (this.options.allowMultiParagraphSelection === false && this.multipleBlockElementsSelected())) {
-                    return this.hideToolbar();
-                }
-
-                this.showAndUpdateToolbar();
+            if (this.base.preventSelectionUpdates) {
+                return;
             }
+
+            // If no editable has focus OR selection is inside contenteditable = false
+            // hide toolbar
+            if (!this.base.getFocusedElement() ||
+                    Selection.selectionInContentEditableFalse(this.options.contentWindow)) {
+                return this.hideToolbar();
+            }
+
+            // If there's no selection element, selection element doesn't belong to this editor
+            // or toolbar is disabled for this selection element
+            // hide toolbar
+            var selectionElement = Selection.getSelectionElement(this.options.contentWindow);
+            if (!selectionElement ||
+                    this.base.elements.indexOf(selectionElement) === -1 ||
+                    selectionElement.getAttribute('data-disable-toolbar')) {
+                return this.hideToolbar();
+            }
+
+            // Now we know there's a focused editable with a selection
+
+            // If the updateOnEmptySelection option is true, show the toolbar
+            if (this.options.updateOnEmptySelection && this.options.staticToolbar) {
+                return this.showAndUpdateToolbar();
+            }
+
+            // If we don't have a 'valid' selection -> hide toolbar
+            if (this.options.contentWindow.getSelection().toString().trim() === '' ||
+                (this.options.allowMultiParagraphSelection === false && this.multipleBlockElementsSelected())) {
+                return this.hideToolbar();
+            }
+
+            this.showAndUpdateToolbar();
         },
 
         // leaving here backward compatibility / statics

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -80,6 +80,32 @@ var Util;
             return false;
         },
 
+        /**
+         * Returns true if the key associated to the event is inside keys array
+         *
+         * @see : https://github.com/jquery/jquery/blob/0705be475092aede1eddae01319ec931fb9c65fc/src/event.js#L473-L484
+         * @see : http://stackoverflow.com/q/4471582/569101
+         */
+        isKey: function (event, keys) {
+            var keyCode = event.which;
+
+            // getting the key code from event
+            if (null === keyCode) {
+                keyCode = event.charCode !== null ? event.charCode : event.keyCode;
+            }
+
+            // it's not an array let's just compare strings!
+            if (false === Array.isArray(keys)) {
+                return keyCode === keys;
+            }
+
+            if (-1 === keys.indexOf(keyCode)) {
+                return false;
+            }
+
+            return true;
+        },
+
         parentElements: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
 
         extend: function extend(/* dest, source1, source2, ...*/) {


### PR DESCRIPTION
Instead of always trying to find which key is associated to an event for all browsers, I created a helper in Util to return this key.

I follow what is already done by jQuery.

It'll ease the transition when the `.key` will be compatible with all browsers (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)

Are you all ok with the `Util.key(event)` name ? Or should we use `Util.keyCode(event)` ?