### PR TITLE
remove name of function.

### DIFF
--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -5,7 +5,7 @@ var Toolbar;
 (function () {
     'use strict';
 
-    Toolbar = function Toolbar(instance) {
+    Toolbar = function (instance) {
         this.base = instance;
         this.options = instance.options;
 


### PR DESCRIPTION
* none of the other functions do? or did?
* now that everything is Extension.extend, no named functions are used as ctors
* somehow, someway, the duplicate `var Toolbar; (function(){ Toolbar = function Toolbar(instance){} )();`
  is causing uglify2 to output `var x; (function() e = function e(e){})();` which is clearly not right